### PR TITLE
Fix nullable array shows an empty array

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,17 @@ Interactive command line tool for Cloud Spanner.
 ## Description
 
 `spanner-cli` is an interactive command line tool for [Google Cloud Spanner](https://cloud.google.com/spanner/).  
-You can control your Spanner databases with idiomatic SQL commands. If you're familiar with `mysql(1)` command,
-you can find this tool is similar to that.
-
-This tool is still **ALPHA** quality. Do not use this tool for production databases.
-
-This tool is not an official Google product.
+You can control your Spanner databases with idiomatic SQL commands.
 
 ## Install
 
-You can get the latest binary from [Releases](https://github.com/cloudspannerecosystem/spanner-cli/releases).
-
-Or if you have `go`, just execute `go get` from your console.
+If you have `go`, you can install using `go get`.
 
 ```
 go get -u github.com/cloudspannerecosystem/spanner-cli
 ```
+
+Otherwise, you can download the binary from the [releases page](https://github.com/cloudspannerecosystem/spanner-cli/releases).
 
 ## Usage
 
@@ -110,7 +105,7 @@ Bye
 
 ### Batch mode
 
-By passing SQL from standard input, `spanner-cli` runs in batch mode
+By passing SQL from standard input, `spanner-cli` runs in batch mode.
 
 ```
 $ echo 'SELECT * FROM users;' | spanner-cli -p myproject -i myinstance -d mydb
@@ -119,7 +114,7 @@ id      name    active
 2       bar     false
 ```
 
-You can also pass SQL from command line option `-e`
+You can also pass SQL with command line option `-e`.
 
 ```
 $ spanner-cli -p myproject -i myinstance -d mydb -e 'SELECT * FROM users;'
@@ -128,7 +123,7 @@ id      name    active
 2       bar     false
 ```
 
-With `-t` option, results are displayed in table format
+With `-t` option, results are displayed in table format.
 
 ```
 $ spanner-cli -p myproject -i myinstance -d mydb -e 'SELECT * FROM users;' -t
@@ -208,7 +203,7 @@ The default prompt is `spanner\t> `.
 
 ## Config file
 
-This tool supports a configuration file called `spanner_cli.cnf` like `my.cnf`.  
+This tool supports a configuration file called `spanner_cli.cnf`, similar to `my.cnf`.  
 The config file path must be `~/.spanner_cli.cnf`.  
 In the config file, you can set default option values for command line options.
 
@@ -223,13 +218,13 @@ prompt = "[\\p:\\i:\\d]\\t> "
 
 ## How to develop
 
-Run unit tests
+Run unit tests.
 
 ```
 $ make test
 ```
 
-Run unit tests and integration tests, which connects to real Cloud Spanner database.
+Run integration tests, which connects to real Cloud Spanner database.
 
 ```
 $ PROJECT=${PROJECT_ID} INSTANCE=${INSTANCE_ID} DATABASE=${DATABASE_ID} CREDENTIAL=${CREDENTIAL} make test
@@ -237,5 +232,12 @@ $ PROJECT=${PROJECT_ID} INSTANCE=${INSTANCE_ID} DATABASE=${DATABASE_ID} CREDENTI
 
 ## TODO
 
-* STRUCT data type
-* show secondary index by "SHOW CREATE TABLE"
+* Support `STRUCT` data type
+* Support `DROP DATABASE`
+* Show secondary index by "SHOW CREATE TABLE"
+
+## Disclaimer
+
+Do not use this tool for production databases as the tool is still alpha quality.
+
+This tool is not an official Google product.

--- a/decoder.go
+++ b/decoder.go
@@ -38,6 +38,9 @@ func DecodeColumn(column spanner.GenericColumnValue) (string, error) {
 			if err := column.Decode(&vs); err != nil {
 				return "", err
 			}
+			if vs == nil {
+				return "NULL", nil
+			}
 			for _, v := range vs {
 				decoded = append(decoded, nullBoolToString(v))
 			}
@@ -45,6 +48,9 @@ func DecodeColumn(column spanner.GenericColumnValue) (string, error) {
 			var vs [][]byte
 			if err := column.Decode(&vs); err != nil {
 				return "", err
+			}
+			if vs == nil {
+				return "NULL", nil
 			}
 			for _, v := range vs {
 				decoded = append(decoded, nullBytesToString(v))
@@ -54,6 +60,9 @@ func DecodeColumn(column spanner.GenericColumnValue) (string, error) {
 			if err := column.Decode(&vs); err != nil {
 				return "", err
 			}
+			if vs == nil {
+				return "NULL", nil
+			}
 			for _, v := range vs {
 				decoded = append(decoded, nullFloat64ToString(v))
 			}
@@ -61,6 +70,9 @@ func DecodeColumn(column spanner.GenericColumnValue) (string, error) {
 			var vs []spanner.NullInt64
 			if err := column.Decode(&vs); err != nil {
 				return "", err
+			}
+			if vs == nil {
+				return "NULL", nil
 			}
 			for _, v := range vs {
 				decoded = append(decoded, nullInt64ToString(v))
@@ -70,6 +82,9 @@ func DecodeColumn(column spanner.GenericColumnValue) (string, error) {
 			if err := column.Decode(&vs); err != nil {
 				return "", err
 			}
+			if vs == nil {
+				return "NULL", nil
+			}
 			for _, v := range vs {
 				decoded = append(decoded, nullStringToString(v))
 			}
@@ -78,6 +93,9 @@ func DecodeColumn(column spanner.GenericColumnValue) (string, error) {
 			if err := column.Decode(&vs); err != nil {
 				return "", err
 			}
+			if vs == nil {
+				return "NULL", nil
+			}
 			for _, v := range vs {
 				decoded = append(decoded, nullTimeToString(v))
 			}
@@ -85,6 +103,9 @@ func DecodeColumn(column spanner.GenericColumnValue) (string, error) {
 			var vs []spanner.NullDate
 			if err := column.Decode(&vs); err != nil {
 				return "", err
+			}
+			if vs == nil {
+				return "NULL", nil
 			}
 			for _, v := range vs {
 				decoded = append(decoded, nullDateToString(v))

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -63,6 +63,7 @@ func TestDecodeRow(t *testing.T) {
 		{createRow(t, []interface{}{spanner.NullDate{Date: civil.DateOf(time.Unix(1516676400, 0)), Valid: true}, spanner.NullDate{Date: civil.DateOf(time.Unix(0, 0)), Valid: false}}), []string{"2018-01-23", "NULL"}},
 
 		// array type
+		{createRow(t, []interface{}{[]string{}}), []string{"[]"}},
 		{createRow(t, []interface{}{[]bool{true, false}}), []string{"[true, false]"}},
 		{createRow(t, []interface{}{[][]byte{{'a', 'b', 'c'}, []byte{'e', 'f', 'g'}}}), []string{"[YWJj, ZWZn]"}},
 		{createRow(t, []interface{}{[]float64{1.23, 2.45}}), []string{"[1.230000, 2.450000]"}},
@@ -70,6 +71,15 @@ func TestDecodeRow(t *testing.T) {
 		{createRow(t, []interface{}{[]string{"foo", "bar"}}), []string{"[foo, bar]"}},
 		{createRow(t, []interface{}{[]time.Time{time.Unix(1516676400, 0), time.Unix(1516680000, 0)}}), []string{"[2018-01-23T03:00:00Z, 2018-01-23T04:00:00Z]"}},
 		{createRow(t, []interface{}{[]civil.Date{civil.DateOf(time.Unix(1516676400, 0)), civil.DateOf(time.Unix(1516762800, 0))}}), []string{"[2018-01-23, 2018-01-24]"}},
+
+		// array nullable type
+		{createRow(t, []interface{}{[]bool(nil)}), []string{"NULL"}},
+		{createRow(t, []interface{}{[]byte(nil)}), []string{"NULL"}},
+		{createRow(t, []interface{}{[]float64(nil)}), []string{"NULL"}},
+		{createRow(t, []interface{}{[]int64(nil)}), []string{"NULL"}},
+		{createRow(t, []interface{}{[]string(nil)}), []string{"NULL"}},
+		{createRow(t, []interface{}{[]time.Time(nil)}), []string{"NULL"}},
+		{createRow(t, []interface{}{[]civil.Date(nil)}), []string{"NULL"}},
 	}
 
 	for _, test := range validTests {


### PR DESCRIPTION
Fixed nullable array always show an empty array string.

Before:
```
> select ArrayNullCol from t1;
+--------------+
| ArrayNullCol |
+--------------+
| []           |
| []           |
| [1, 2, 3]    |
+--------------+
```

After:
```
> select ArrayNullCol from t1;
+--------------+
| ArrayNullCol |
+--------------+
| NULL         | # This is actually NULL
| []           | # This is an empty array
| [1, 2, 3]    |
+--------------+
```

Also minor updated README.