### PR TITLE
Implement --file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,18 @@ Otherwise, you can download the binary from the [releases page](https://github.c
 Usage:
   spanner-cli [OPTIONS]
 
-Application Options:
-  -p, --project=  (required) GCP Project ID.
-  -i, --instance= (required) Cloud Spanner Instance ID
-  -d, --database= (required) Cloud Spanner Database ID.
-  -e, --execute=  Execute SQL statement and quit.
-  -t, --table     Display output in table format for batch mode.
+spanner:
+  -p, --project=    (required) GCP Project ID.
+  -i, --instance=   (required) Cloud Spanner Instance ID
+  -d, --database=   (required) Cloud Spanner Database ID.
+  -e, --execute=    Execute SQL statement and quit.
+  -f, --file=       Execute SQL statement from file and quit.
+  -t, --table       Display output in table format for batch mode.
       --credential= Use the specific credential file
-      --prompt=   Set the prompt to the specified format
+      --prompt=     Set the prompt to the specified format
 
 Help Options:
-  -h, --help      Show this help message
+  -h, --help        Show this help message
 ```
 
 Unless you specify a credential file with `--credential`, this tool uses [Application Default Credentials](https://cloud.google.com/docs/authentication/production?hl=en#providing_credentials_to_your_application) as credential source to connect to Spanner databases.  

--- a/main.go
+++ b/main.go
@@ -61,19 +61,26 @@ func main() {
 		exitf("Failed to connect to Spanner: %v", err)
 	}
 
-	input, err := readStdin()
-	if err != nil {
-		exitf("Read from stdin failed: %v", err)
-	}
-
+	var input string
 	if opts.Execute != "" {
 		input = opts.Execute
-	} else if opts.File != "" && opts.File != "-" {
+	} else if opts.File == "-" {
+		b, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			exitf("Read from stdin failed: %v", err)
+		}
+		input = string(b)
+	} else if opts.File != "" {
 		b, err := ioutil.ReadFile(opts.File)
 		if err != nil {
 			exitf("Read from file %v failed: %v", opts.File, err)
 		}
 		input = string(b)
+	} else {
+		input, err = readStdin()
+		if err != nil {
+			exitf("Read from stdin failed: %v", err)
+		}
 	}
 
 	var exitCode int

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	if opts.Execute != "" {
 		input = opts.Execute
-	} else if opts.File != "" {
+	} else if opts.File != "" && opts.File != "-" {
 		b, err := ioutil.ReadFile(opts.File)
 		if err != nil {
 			exitf("Read from file %v failed: %v", opts.File, err)


### PR DESCRIPTION
Implement `--file`(`-f`) option.

```
$ spanner-cli -f schema.sql
```

Already `spanner-cli` can read SQL statements from a file in the following ways:

```
$ spanner-cli -e "$(cat schema.sql)"
$ cat schema.sql | spanner-cli
$ spanner-cli < schema.sql"
```

but the dedicated `--file`(`-f`) option is more intuitive for some users. It can be described in `--help`!