### PR TITLE
Add verbose

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -366,17 +366,17 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool
 	}
 
 	if withStats {
-		var readTimestampStr string
+		var timestampStr string
 		if verbose && !result.Timestamp.IsZero() {
-			readTimestampStr = fmt.Sprintf(" timestamp(%v)", result.Timestamp)
+			timestampStr = fmt.Sprintf(" timestamp(%v)", result.Timestamp)
 		}
 		if result.IsMutation {
-			fmt.Fprintf(out, "Query OK, %d rows affected (%s)%v\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, readTimestampStr)
+			fmt.Fprintf(out, "Query OK, %d rows affected (%s)%v\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, timestampStr)
 		} else {
 			if result.Stats.AffectedRows == 0 {
-				fmt.Fprintf(out, "Empty set (%s)%v\n", result.Stats.ElapsedTime, readTimestampStr)
+				fmt.Fprintf(out, "Empty set (%s)%v\n", result.Stats.ElapsedTime, timestampStr)
 			} else {
-				fmt.Fprintf(out, "%d rows in set (%s)%v\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, readTimestampStr)
+				fmt.Fprintf(out, "%d rows in set (%s)%v\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, timestampStr)
 			}
 		}
 	}

--- a/cli.go
+++ b/cli.go
@@ -368,7 +368,7 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool
 	if withStats {
 		var timestampStr string
 		if verbose && !result.Timestamp.IsZero() {
-			timestampStr = fmt.Sprintf(" timestamp(%v)", result.Timestamp.Format(time.RFC3339Nano))
+			timestampStr = fmt.Sprintf(" timestamp(%s)", result.Timestamp.Format(time.RFC3339Nano))
 		}
 		if result.IsMutation {
 			fmt.Fprintf(out, "Query OK, %d rows affected (%s)%v\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, timestampStr)

--- a/cli.go
+++ b/cli.go
@@ -368,7 +368,7 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool
 	if withStats {
 		var timestampStr string
 		if verbose && !result.Timestamp.IsZero() {
-			timestampStr = fmt.Sprintf(" timestamp(%v)", result.Timestamp)
+			timestampStr = fmt.Sprintf(" timestamp(%v)", result.Timestamp.Format(time.RFC3339Nano))
 		}
 		if result.IsMutation {
 			fmt.Fprintf(out, "Query OK, %d rows affected (%s)%v\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, timestampStr)

--- a/cli.go
+++ b/cli.go
@@ -44,6 +44,7 @@ type Cli struct {
 	InStream   io.ReadCloser
 	OutStream  io.Writer
 	ErrStream  io.Writer
+	Verbose bool
 }
 
 var defaultClientConfig = spanner.ClientConfig{
@@ -54,7 +55,7 @@ var defaultClientConfig = spanner.ClientConfig{
 	},
 }
 
-func NewCli(projectId, instanceId, databaseId string, prompt string, credential []byte, inStream io.ReadCloser, outStream io.Writer, errStream io.Writer) (*Cli, error) {
+func NewCli(projectId, instanceId, databaseId string, prompt string, credential []byte, inStream io.ReadCloser, outStream io.Writer, errStream io.Writer, verbose bool) (*Cli, error) {
 	ctx := context.Background()
 	session, err := createSession(ctx, projectId, instanceId, databaseId, credential)
 	if err != nil {
@@ -72,6 +73,7 @@ func NewCli(projectId, instanceId, databaseId string, prompt string, credential 
 		InStream:   inStream,
 		OutStream:  outStream,
 		ErrStream:  errStream,
+		Verbose: verbose,
 	}, nil
 }
 
@@ -368,9 +370,9 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool
 			fmt.Fprintf(out, "Query OK, %d rows affected (%s)\n", result.Stats.AffectedRows, result.Stats.ElapsedTime)
 		} else {
 			if result.Stats.AffectedRows == 0 {
-				fmt.Fprintf(out, "Empty set (%s)\n", result.Stats.ElapsedTime)
+				fmt.Fprintf(out, "Empty set (%s), readTimestamp(%v)\n", result.Stats.ElapsedTime, result.Timestamp)
 			} else {
-				fmt.Fprintf(out, "%d rows in set (%s)\n", result.Stats.AffectedRows, result.Stats.ElapsedTime)
+				fmt.Fprintf(out, "%d rows in set (%s), readTimestamp(%v)\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, result.Timestamp)
 			}
 		}
 	}

--- a/cli.go
+++ b/cli.go
@@ -368,7 +368,7 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool
 	if withStats {
 		var timestampStr string
 		if verbose && !result.Timestamp.IsZero() {
-			timestampStr = fmt.Sprintf(" timestamp(%s)", result.Timestamp.Format(time.RFC3339Nano))
+			timestampStr = fmt.Sprintf(", timestamp: %s", result.Timestamp.Format(time.RFC3339Nano))
 		}
 		if result.IsMutation {
 			fmt.Fprintf(out, "Query OK, %d rows affected (%s)%s\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, timestampStr)

--- a/cli.go
+++ b/cli.go
@@ -371,12 +371,12 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool
 			timestampStr = fmt.Sprintf(" timestamp(%s)", result.Timestamp.Format(time.RFC3339Nano))
 		}
 		if result.IsMutation {
-			fmt.Fprintf(out, "Query OK, %d rows affected (%s)%v\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, timestampStr)
+			fmt.Fprintf(out, "Query OK, %d rows affected (%s)%s\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, timestampStr)
 		} else {
 			if result.Stats.AffectedRows == 0 {
-				fmt.Fprintf(out, "Empty set (%s)%v\n", result.Stats.ElapsedTime, timestampStr)
+				fmt.Fprintf(out, "Empty set (%s)%s\n", result.Stats.ElapsedTime, timestampStr)
 			} else {
-				fmt.Fprintf(out, "%d rows in set (%s)%v\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, timestampStr)
+				fmt.Fprintf(out, "%d rows in set (%s)%s\n", result.Stats.AffectedRows, result.Stats.ElapsedTime, timestampStr)
 			}
 		}
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -69,7 +69,7 @@ func TestPrintResult(t *testing.T) {
 			Stats:      Stats{},
 			IsMutation: false,
 		}
-		printResult(out, result, DisplayModeTable, false)
+		printResult(out, result, DisplayModeTable, false, false)
 
 		expected := strings.TrimPrefix(`
 +-----+-----+
@@ -97,7 +97,7 @@ func TestPrintResult(t *testing.T) {
 			Stats:      Stats{},
 			IsMutation: false,
 		}
-		printResult(out, result, DisplayModeVertical, false)
+		printResult(out, result, DisplayModeVertical, false, false)
 
 		expected := strings.TrimPrefix(`
 *************************** 1. row ***************************

--- a/cli_test.go
+++ b/cli_test.go
@@ -125,7 +125,7 @@ bar: 4
 			Stats:      Stats{},
 			IsMutation: false,
 		}
-		printResult(out, result, DisplayModeTab, false)
+		printResult(out, result, DisplayModeTab, false, false)
 
 		expected := "foo\tbar\n" +
 			"1\t2\n" +

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ type spannerOptions struct {
 	DatabaseId string `short:"d" long:"database" description:"(required) Cloud Spanner Database ID."`
 	Execute    string `short:"e" long:"execute" description:"Execute SQL statement and quit."`
 	Table      bool   `short:"t" long:"table" description:"Display output in table format for batch mode."`
-	Verbose      bool   `short:"v" long:"verbose" description:"Display verbose output."`
+	Verbose    bool   `short:"v" long:"verbose" description:"Display verbose output."`
 	Credential string `long:"credential" description:"Use the specific credential file"`
 	Prompt     string `long:"prompt" description:"Set the prompt to the specified format"`
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ type spannerOptions struct {
 	DatabaseId string `short:"d" long:"database" description:"(required) Cloud Spanner Database ID."`
 	Execute    string `short:"e" long:"execute" description:"Execute SQL statement and quit."`
 	Table      bool   `short:"t" long:"table" description:"Display output in table format for batch mode."`
+	Verbose      bool   `short:"v" long:"verbose" description:"Display verbose output."`
 	Credential string `long:"credential" description:"Use the specific credential file"`
 	Prompt     string `long:"prompt" description:"Set the prompt to the specified format"`
 }
@@ -52,7 +53,7 @@ func main() {
 		}
 	}
 
-	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, cred, os.Stdin, os.Stdout, os.Stderr)
+	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose)
 	if err != nil {
 		exitf("Failed to connect to Spanner: %v", err)
 	}

--- a/session.go
+++ b/session.go
@@ -14,8 +14,8 @@ import (
 )
 
 type txnFinishResult struct {
-	Err             error
 	CommitTimestamp time.Time
+	Err             error
 }
 
 type Session struct {

--- a/session.go
+++ b/session.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-type TxnFinishResponse struct {
+type txnFinishResult struct {
 	Err             error
 	CommitTimestamp time.Time
 }
@@ -28,7 +28,7 @@ type Session struct {
 
 	// for read-write transaction
 	rwTxn         *spanner.ReadWriteTransaction
-	txnFinished   chan TxnFinishResponse
+	txnFinished   chan txnFinishResult
 	committedChan chan bool
 
 	// for read-only transaction
@@ -63,7 +63,7 @@ func NewSession(ctx context.Context, projectId string, instanceId string, databa
 		databaseId:    databaseId,
 		client:        client,
 		adminClient:   adminClient,
-		txnFinished:   make(chan TxnFinishResponse),
+		txnFinished:   make(chan txnFinishResult),
 		committedChan: make(chan bool),
 	}, nil
 }

--- a/session.go
+++ b/session.go
@@ -13,6 +13,11 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+type TxnFinishResponse struct {
+	Err             error
+	CommitTimestamp time.Time
+}
+
 type Session struct {
 	ctx         context.Context
 	projectId   string
@@ -23,7 +28,7 @@ type Session struct {
 
 	// for read-write transaction
 	rwTxn         *spanner.ReadWriteTransaction
-	txnFinished   chan error
+	txnFinished   chan TxnFinishResponse
 	committedChan chan bool
 
 	// for read-only transaction
@@ -58,7 +63,7 @@ func NewSession(ctx context.Context, projectId string, instanceId string, databa
 		databaseId:    databaseId,
 		client:        client,
 		adminClient:   adminClient,
-		txnFinished:   make(chan error),
+		txnFinished:   make(chan TxnFinishResponse),
 		committedChan: make(chan bool),
 	}, nil
 }

--- a/statement.go
+++ b/statement.go
@@ -191,7 +191,7 @@ func (s *SelectStatement) Execute(session *Session) (*Result, error) {
 		ElapsedTime:  elapsedTime,
 	}
 
-	// ReadOnlyTransaction.Timestamp() is valid after read.
+	// ReadOnlyTransaction.Timestamp() is invalid until read.
 	if targetRoTxn != nil {
 		result.Timestamp, _ = targetRoTxn.Timestamp()
 	}

--- a/statement.go
+++ b/statement.go
@@ -586,7 +586,11 @@ func (s *BeginRoStatement) Execute(session *Session) (*Result, error) {
 	}
 	session.StartRoTxn(txn)
 
-	return &Result{IsMutation: true}, nil
+	// readTimestamp is not obtained until query is emitted
+	_ = txn.Query(context.Background(), spanner.NewStatement("SELECT 1"))
+	readTimestamp, _ := txn.Timestamp()
+
+	return &Result{IsMutation: true, Timestamp: readTimestamp}, nil
 }
 
 type CloseStatement struct{}

--- a/statement.go
+++ b/statement.go
@@ -592,11 +592,7 @@ func (s *BeginRoStatement) Execute(session *Session) (*Result, error) {
 	}
 	session.StartRoTxn(txn)
 
-	// readTimestamp is not obtained until query is emitted
-	_ = txn.Query(context.Background(), spanner.NewStatement("SELECT 1"))
-	readTimestamp, _ := txn.Timestamp()
-
-	return &Result{IsMutation: true, Timestamp: readTimestamp}, nil
+	return &Result{IsMutation: true}, nil
 }
 
 type CloseStatement struct{}

--- a/statement.go
+++ b/statement.go
@@ -591,7 +591,7 @@ func (s *BeginRoStatement) Execute(session *Session) (*Result, error) {
 
 	return &Result{
 		IsMutation: true,
-		Timestamp: determineReadTimestamp(session.ctx, txn),
+		Timestamp:  determineReadTimestamp(session.ctx, txn),
 	}, nil
 }
 

--- a/statement.go
+++ b/statement.go
@@ -155,6 +155,7 @@ func (s *SelectStatement) Execute(session *Session) (*Result, error) {
 		iter = session.roTxn.QueryWithStats(session.ctx, stmt)
 		result.Timestamp, _ = session.roTxn.Timestamp()
 	} else {
+		// Use ReadOnlyTransaction because Single does't obtain read timestamp
 		txn := session.client.ReadOnlyTransaction()
 		defer txn.Close()
 		iter = txn.QueryWithStats(session.ctx, stmt)

--- a/statement.go
+++ b/statement.go
@@ -510,7 +510,7 @@ func (s *BeginRwStatement) Execute(session *Session) (*Result, error) {
 				return rollbackError
 			}
 		})
-		session.txnFinished <- TxnFinishResponse{Err: err, CommitTimestamp: commitTimestamp}
+		session.txnFinished <- txnFinishResult{Err: err, CommitTimestamp: commitTimestamp}
 	}()
 
 	select {
@@ -539,12 +539,12 @@ func (s *CommitStatement) Execute(session *Session) (*Result, error) {
 
 	session.committedChan <- true
 
-	txnFinishResult := <-session.txnFinished
-	if txnFinishResult.Err != nil {
-		return nil, txnFinishResult.Err
+	txnFinishRes := <-session.txnFinished
+	if txnFinishRes.Err != nil {
+		return nil, txnFinishRes.Err
 	}
 
-	result.Timestamp = txnFinishResult.CommitTimestamp
+	result.Timestamp = txnFinishRes.CommitTimestamp
 	return result, nil
 }
 

--- a/statement.go
+++ b/statement.go
@@ -158,7 +158,13 @@ func (s *SelectStatement) Execute(session *Session) (*Result, error) {
 			result.Timestamp = ts
 		}
 	} else {
-		iter = session.client.Single().QueryWithStats(session.ctx, stmt)
+		txn := session.client.ReadOnlyTransaction()
+		defer txn.Close()
+		iter = txn.QueryWithStats(session.ctx, stmt)
+		ts, err := txn.Timestamp()
+		if err == nil {
+			result.Timestamp = ts
+		}
 	}
 	defer iter.Stop()
 

--- a/statement.go
+++ b/statement.go
@@ -535,8 +535,7 @@ func (s *CommitStatement) Execute(session *Session) (*Result, error) {
 	session.committedChan <- true
 
 	txnFinishRes := <-session.txnFinished
-	err := txnFinishRes.Err
-	if err != nil {
+	if err := txnFinishRes.Err; err != nil {
 		return nil, err
 	}
 
@@ -560,8 +559,7 @@ func (s *RollbackStatement) Execute(session *Session) (*Result, error) {
 	session.committedChan <- false
 
 	txnFinishRes := <-session.txnFinished
-	err := txnFinishRes.Err
-	if err != nil && err != rollbackError {
+	if err := txnFinishRes.Err; err != nil && err != rollbackError {
 		return nil, err
 	}
 


### PR DESCRIPTION
Add `--verbose` flag to display read/commit timestamps.
It display timestamps on:
* `BEGIN RO`
  * It needs to emit `SELECT 1` so it changes behavior. Should revert it?
    * discussion https://twitter.com/_NANASI880/status/1244566302221422593
    * Although `google-cloud-go` defer `BeginTransaction` until `Query*()` is called, It makes sense `BEGIN RO` ensures to call `BeginTransaction` RPC.
      * discussion https://twitter.com/furuyamayuki/status/1244861239273984000
* `COMMIT`
* `SELECT` in read only or single
* DML in implicit transaction

ref #28 