### PR TITLE
Fix integration test

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -124,6 +124,7 @@ func setup(t *testing.T, ctx context.Context, dmls []string) (*Session, string, 
 func compareResult(t *testing.T, got *Result, expected *Result) {
 	opts := []cmp.Option{
 		cmpopts.IgnoreFields(Stats{}, "ElapsedTime"),
+		cmpopts.IgnoreFields(Result{}, "Timestamp"),
 	}
 	if !cmp.Equal(got, expected, opts...) {
 		t.Errorf("diff: %s", cmp.Diff(got, expected, opts...))


### PR DESCRIPTION
This issue has happened after merging https://github.com/cloudspannerecosystem/spanner-cli/pull/30.

<details><summary>Failed log: </summary>
<pre><code>
#!/bin/bash -eo pipefail
make test
=== RUN   TestSeparateInput
--- PASS: TestSeparateInput (0.00s)
=== RUN   TestBuildDdlStatements
--- PASS: TestBuildDdlStatements (0.00s)
=== RUN   TestPrintResult
=== RUN   TestPrintResult/DisplayModeTable
=== RUN   TestPrintResult/DisplayModeVertical
=== RUN   TestPrintResult/DisplayModeTab
--- PASS: TestPrintResult (0.00s)
    --- PASS: TestPrintResult/DisplayModeTable (0.00s)
    --- PASS: TestPrintResult/DisplayModeVertical (0.00s)
    --- PASS: TestPrintResult/DisplayModeTab (0.00s)
=== RUN   TestDecodeColumn
=== RUN   TestDecodeColumn/bool
=== RUN   TestDecodeColumn/bytes
=== RUN   TestDecodeColumn/float64
=== RUN   TestDecodeColumn/int64
=== RUN   TestDecodeColumn/string
=== RUN   TestDecodeColumn/timestamp
=== RUN   TestDecodeColumn/date
=== RUN   TestDecodeColumn/null_bool
=== RUN   TestDecodeColumn/null_bytes
=== RUN   TestDecodeColumn/null_float64
=== RUN   TestDecodeColumn/null_int64
=== RUN   TestDecodeColumn/null_string
=== RUN   TestDecodeColumn/null_time
=== RUN   TestDecodeColumn/null_date
=== RUN   TestDecodeColumn/empty_array
=== RUN   TestDecodeColumn/array_bool
=== RUN   TestDecodeColumn/array_bytes
=== RUN   TestDecodeColumn/array_float64
=== RUN   TestDecodeColumn/array_int64
=== RUN   TestDecodeColumn/array_string
=== RUN   TestDecodeColumn/array_timestamp
=== RUN   TestDecodeColumn/array_date
=== RUN   TestDecodeColumn/array_struct
=== RUN   TestDecodeColumn/null_array_bool
=== RUN   TestDecodeColumn/null_array_bytes
=== RUN   TestDecodeColumn/nul_array_float64
=== RUN   TestDecodeColumn/null_array_int64
=== RUN   TestDecodeColumn/null_array_string
=== RUN   TestDecodeColumn/null_array_timestamp
=== RUN   TestDecodeColumn/null_array_date
--- PASS: TestDecodeColumn (0.00s)
    --- PASS: TestDecodeColumn/bool (0.00s)
    --- PASS: TestDecodeColumn/bytes (0.00s)
    --- PASS: TestDecodeColumn/float64 (0.00s)
    --- PASS: TestDecodeColumn/int64 (0.00s)
    --- PASS: TestDecodeColumn/string (0.00s)
    --- PASS: TestDecodeColumn/timestamp (0.00s)
    --- PASS: TestDecodeColumn/date (0.00s)
    --- PASS: TestDecodeColumn/null_bool (0.00s)
    --- PASS: TestDecodeColumn/null_bytes (0.00s)
    --- PASS: TestDecodeColumn/null_float64 (0.00s)
    --- PASS: TestDecodeColumn/null_int64 (0.00s)
    --- PASS: TestDecodeColumn/null_string (0.00s)
    --- PASS: TestDecodeColumn/null_time (0.00s)
    --- PASS: TestDecodeColumn/null_date (0.00s)
    --- PASS: TestDecodeColumn/empty_array (0.00s)
    --- PASS: TestDecodeColumn/array_bool (0.00s)
    --- PASS: TestDecodeColumn/array_bytes (0.00s)
    --- PASS: TestDecodeColumn/array_float64 (0.00s)
    --- PASS: TestDecodeColumn/array_int64 (0.00s)
    --- PASS: TestDecodeColumn/array_string (0.00s)
    --- PASS: TestDecodeColumn/array_timestamp (0.00s)
    --- PASS: TestDecodeColumn/array_date (0.00s)
    --- PASS: TestDecodeColumn/array_struct (0.00s)
    --- PASS: TestDecodeColumn/null_array_bool (0.00s)
    --- PASS: TestDecodeColumn/null_array_bytes (0.00s)
    --- PASS: TestDecodeColumn/nul_array_float64 (0.00s)
    --- PASS: TestDecodeColumn/null_array_int64 (0.00s)
    --- PASS: TestDecodeColumn/null_array_string (0.00s)
    --- PASS: TestDecodeColumn/null_array_timestamp (0.00s)
    --- PASS: TestDecodeColumn/null_array_date (0.00s)
=== RUN   TestDecodeRow
=== RUN   TestDecodeRow/non-null_columns
=== RUN   TestDecodeRow/non-null_column_and_null_column
--- PASS: TestDecodeRow (0.00s)
    --- PASS: TestDecodeRow/non-null_columns (0.00s)
    --- PASS: TestDecodeRow/non-null_column_and_null_column (0.00s)
=== RUN   TestSelect
--- FAIL: TestSelect (15.53s)
    integration_test.go:129: diff:   &main.Result{
          	... // 2 identical fields
          	Stats:      main.Stats{AffectedRows: 2},
          	IsMutation: false,
        - 	Timestamp:  s"2020-03-31 06:27:43.887135 +0000 UTC",
        + 	Timestamp:  s"0001-01-01 00:00:00 +0000 UTC",
          }
=== RUN   TestDml
--- FAIL: TestDml (13.13s)
    integration_test.go:129: diff:   &main.Result{
          	... // 2 identical fields
          	Stats:      main.Stats{AffectedRows: 2},
          	IsMutation: true,
        - 	Timestamp:  s"2020-03-31 06:27:58.382745 +0000 UTC",
        + 	Timestamp:  s"0001-01-01 00:00:00 +0000 UTC",
          }
=== RUN   TestReadWriteTransaction
=== RUN   TestReadWriteTransaction/begin,_insert,_and_commit
=== RUN   TestReadWriteTransaction/begin,_insert,_and_rollback
=== RUN   TestReadWriteTransaction/heartbeat:_transaction_is_not_aborted_even_if_the_transaction_is_idle
--- FAIL: TestReadWriteTransaction (45.37s)
    --- FAIL: TestReadWriteTransaction/begin,_insert,_and_commit (12.97s)
        integration_test.go:129: diff:   &main.Result{
              	... // 2 identical fields
              	Stats:      main.Stats{},
              	IsMutation: true,
            - 	Timestamp:  s"2020-03-31 06:28:09.600252 +0000 UTC",
            + 	Timestamp:  s"0001-01-01 00:00:00 +0000 UTC",
              }
    --- PASS: TestReadWriteTransaction/begin,_insert,_and_rollback (14.82s)
    --- PASS: TestReadWriteTransaction/heartbeat:_transaction_is_not_aborted_even_if_the_transaction_is_idle (17.58s)
=== RUN   TestReadOnlyTransaction
=== RUN   TestReadOnlyTransaction/begin_ro,_query,_and_close
=== RUN   TestReadOnlyTransaction/begin_ro_with_stale_read
--- FAIL: TestReadOnlyTransaction (62.41s)
    --- FAIL: TestReadOnlyTransaction/begin_ro,_query,_and_close (19.48s)
        integration_test.go:129: diff:   &main.Result{
              	... // 2 identical fields
              	Stats:      main.Stats{},
              	IsMutation: true,
            - 	Timestamp:  s"2020-03-31 06:29:00.762267 +0000 UTC",
            + 	Timestamp:  s"0001-01-01 00:00:00 +0000 UTC",
              }
        integration_test.go:129: diff:   &main.Result{
              	... // 2 identical fields
              	Stats:      main.Stats{AffectedRows: 2},
              	IsMutation: false,
            - 	Timestamp:  s"2020-03-31 06:29:00.762267 +0000 UTC",
            + 	Timestamp:  s"0001-01-01 00:00:00 +0000 UTC",
              }
    --- FAIL: TestReadOnlyTransaction/begin_ro_with_stale_read (42.94s)
        integration_test.go:129: diff:   &main.Result{
              	... // 2 identical fields
              	Stats:      main.Stats{AffectedRows: 2},
              	IsMutation: false,
            - 	Timestamp:  s"2020-03-31 06:29:17.03767 +0000 UTC",
            + 	Timestamp:  s"0001-01-01 00:00:00 +0000 UTC",
              }
=== RUN   TestShowCreateTable
--- PASS: TestShowCreateTable (10.71s)
=== RUN   TestBuildStatement
--- PASS: TestBuildStatement (0.00s)
FAIL
FAIL	github.com/*********************/***********	147.171s
make: *** [Makefile:25: test] Error 1

Exited with code exit status 2
</code></pre>
</details>