### PR TITLE
Statement separator

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -183,7 +183,7 @@ func (c *Cli) RunBatch(input string, displayTable bool) int {
 		return exitCodeSuccess
 	}
 
-	for _, separated := range separateInput(input) {
+	for _, separated := range newSeparator(input).separate() {
 		stmt, err := BuildStatement(separated.statement)
 		if err != nil {
 			c.PrintBatchError(err)
@@ -312,16 +312,6 @@ func readInteractiveInput(rl *readline.Instance) (string, string, error) {
 	}
 }
 
-// separateInput separates input to each statement.
-func separateInput(input string) []inputStatement {
-	s := newSeparator(input)
-	separated, err := s.separate()
-	if err != nil {
-		// TODO
-	}
-	return separated
-}
-
 func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool, verbose bool) {
 	if mode == DisplayModeTable {
 		table := tablewriter.NewWriter(out)
@@ -380,7 +370,7 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool
 // buildDdlStatements build batched statement only if all statements are DDL statements
 func buildDdlStatements(input string) Statement {
 	var ddls []string
-	for _, separated := range separateInput(input) {
+	for _, separated := range newSeparator(input).separate() {
 		stmt, err := BuildStatement(separated.statement)
 		if err != nil {
 			return nil

--- a/cli.go
+++ b/cli.go
@@ -183,7 +183,7 @@ func (c *Cli) RunBatch(input string, displayTable bool) int {
 		return exitCodeSuccess
 	}
 
-	for _, separated := range newSeparator(input).separate() {
+	for _, separated := range separateInput(input) {
 		stmt, err := BuildStatement(separated.statement)
 		if err != nil {
 			c.PrintBatchError(err)
@@ -370,7 +370,7 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool
 // buildDdlStatements build batched statement only if all statements are DDL statements
 func buildDdlStatements(input string) Statement {
 	var ddls []string
-	for _, separated := range newSeparator(input).separate() {
+	for _, separated := range separateInput(input) {
 		stmt, err := BuildStatement(separated.statement)
 		if err != nil {
 			return nil

--- a/cli.go
+++ b/cli.go
@@ -312,35 +312,14 @@ func readInteractiveInput(rl *readline.Instance) (string, string, error) {
 	}
 }
 
-// Separate input to each statement.
+// separateInput separates input to each statement.
 func separateInput(input string) []inputStatement {
-	input = strings.TrimSpace(input)
-
-	// NOTE: This logic doesn't do syntactic analysis, but just checks the delimiter position,
-	// so it's fragile for the case that delimiters appear in strings.
-	var statements []inputStatement
-	for input != "" {
-		if idx := strings.Index(input, delimiterHorizontal); idx != -1 {
-			statements = append(statements, inputStatement{
-				statement: strings.TrimSpace(input[:idx]),
-				delimiter: delimiterHorizontal,
-			})
-			input = strings.TrimSpace(input[idx+1:])
-		} else if idx := strings.Index(input, delimiterVertical); idx != -1 {
-			statements = append(statements, inputStatement{
-				statement: strings.TrimSpace(input[:idx]),
-				delimiter: delimiterVertical,
-			})
-			input = strings.TrimSpace(input[idx+2:]) // +2 for \ and G
-		} else {
-			statements = append(statements, inputStatement{
-				statement: strings.TrimSpace(input),
-				delimiter: delimiterHorizontal, // default horizontal
-			})
-			break
-		}
+	s := newSeparator(input)
+	separated, err := s.separate()
+	if err != nil {
+		// TODO
 	}
-	return statements
+	return separated
 }
 
 func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool, verbose bool) {

--- a/cli_test.go
+++ b/cli_test.go
@@ -17,48 +17,6 @@ func (n *nopCloser) Close() error {
 	return nil
 }
 
-func equalInputStatementSlice(a []inputStatement, b []inputStatement) bool {
-	if a == nil || b == nil {
-		return false
-	}
-	if len(a) != len(b) {
-		return false
-	}
-	for i := 0; i < len(a); i++ {
-		if a[i].statement != b[i].statement {
-			return false
-		}
-		if a[i].delimiter != b[i].delimiter {
-			return false
-		}
-	}
-	return true
-}
-
-func TestSeparateInput(t *testing.T) {
-	tests := []struct {
-		Input    string
-		Expected []inputStatement
-	}{
-		{`SELECT * FROM t1`, []inputStatement{inputStatement{"SELECT * FROM t1", delimiterHorizontal}}},
-		{`SELECT * FROM t1;`, []inputStatement{inputStatement{"SELECT * FROM t1", delimiterHorizontal}}},
-		{"SELECT * FROM t1\n", []inputStatement{inputStatement{"SELECT * FROM t1", delimiterHorizontal}}},
-		{`SELECT * FROM t1\G`, []inputStatement{inputStatement{"SELECT * FROM t1", delimiterVertical}}},
-		{`SELECT * FROM t1; SELECT * FROM t2\G`, []inputStatement{inputStatement{"SELECT * FROM t1", delimiterHorizontal}, inputStatement{"SELECT * FROM t2", delimiterVertical}}},
-		{`SELECT * FROM t1\G SELECT * FROM t2`, []inputStatement{inputStatement{"SELECT * FROM t1", delimiterVertical}, inputStatement{"SELECT * FROM t2", delimiterHorizontal}}},
-		{`SELECT * FROM t1; abcd `, []inputStatement{inputStatement{"SELECT * FROM t1", delimiterHorizontal}, inputStatement{"abcd", delimiterHorizontal}}},
-		{"SELECT\n*\nFROM t1;", []inputStatement{inputStatement{"SELECT\n*\nFROM t1", delimiterHorizontal}}},
-	}
-
-	for _, test := range tests {
-		got := separateInput(test.Input)
-
-		if !equalInputStatementSlice(got, test.Expected) {
-			t.Errorf("invalid separation: expected = %v, but got = %v", test.Expected, got)
-		}
-	}
-}
-
 func TestBuildDdlStatements(t *testing.T) {
 	tests := []struct {
 		Input    string

--- a/cli_test.go
+++ b/cli_test.go
@@ -71,10 +71,18 @@ func TestReadInteractiveInput(t *testing.T) {
 		},
 		{
 			desc:  "multi lines with vertical delimiter",
-			input: "SELECT\n* FROM\n t1\n\\G",
+			input: "SELECT\n* FROM\n t1\\G\n",
 			want: &inputStatement{
 				statement: "SELECT\n* FROM\n t1",
 				delim:     delimiterVertical,
+			},
+		},
+		{
+			desc:  "multi lines with multiple comments",
+			input: "SELECT\n/* comment */1,\n# comment\n2;\n",
+			want: &inputStatement{
+				statement: "SELECT\n1,\n2",
+				delim:     delimiterHorizontal,
 			},
 		},
 		{

--- a/cli_test.go
+++ b/cli_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"strings"
 	"testing"
 
+	"github.com/chzyer/readline"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -41,6 +43,65 @@ func TestBuildDdlStatements(t *testing.T) {
 		if !cmp.Equal(got, test.Expected) {
 			t.Errorf("invalid result: %v", cmp.Diff(test.Expected, got))
 		}
+	}
+}
+
+func TestReadInteractiveInput(t *testing.T) {
+	for _, tt := range []struct {
+		desc  string
+		input string
+		want  *inputStatement
+		wantError bool
+	}{
+		{
+			desc:  "single line",
+			input: "SELECT 1;\n",
+			want: &inputStatement{
+				statement: "SELECT 1",
+				delim:     delimiterHorizontal,
+			},
+		},
+		{
+			desc:  "multi lines",
+			input: "SELECT\n* FROM\n t1\n;\n",
+			want: &inputStatement{
+				statement: "SELECT\n* FROM\n t1",
+				delim:     delimiterHorizontal,
+			},
+		},
+		{
+			desc:  "multi lines with vertical delimiter",
+			input: "SELECT\n* FROM\n t1\n\\G",
+			want: &inputStatement{
+				statement: "SELECT\n* FROM\n t1",
+				delim:     delimiterVertical,
+			},
+		},
+		{
+			desc:  "multiple statements",
+			input: "SELECT 1; SELECT 2;",
+			want: nil,
+			wantError: true,
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			rl, err := readline.NewEx(&readline.Config{
+				Stdin:  ioutil.NopCloser(strings.NewReader(tt.input)),
+				Stdout: ioutil.Discard,
+				Stderr: ioutil.Discard,
+			})
+			if err != nil {
+				t.Fatalf("unexpected readline.NewEx() error: %v", err)
+			}
+
+			got, err := readInteractiveInput(rl, "")
+			if err != nil && !tt.wantError {
+				t.Errorf("readInteractiveInput(%q) got error: %v", tt.input, err)
+			}
+			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(inputStatement{})); diff != "" {
+				t.Errorf("difference in statement: (-want +got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/separator.go
+++ b/separator.go
@@ -163,13 +163,15 @@ func (s *separator) separate() []inputStatement {
 		}
 	}
 
+	// flush remained
 	if s.sb.Len() > 0 {
-		// flush remained
-		statements = append(statements, inputStatement{
-			statement: strings.TrimSpace(s.sb.String()),
-			delimiter: delimiterHorizontal,
-		})
-		s.sb.Reset()
+		if str := strings.TrimSpace(s.sb.String()); len(str) > 0 {
+			statements = append(statements, inputStatement{
+				statement: str,
+				delimiter: delimiterHorizontal,
+			})
+			s.sb.Reset()
+		}
 	}
 	return statements
 }

--- a/separator.go
+++ b/separator.go
@@ -146,6 +146,7 @@ func (s *separator) separate() []inputStatement {
 						s.consumeString()
 					}
 				}
+				break
 			}
 			if !str {
 				s.sb.WriteRune(s.str[0])

--- a/separator.go
+++ b/separator.go
@@ -58,12 +58,12 @@ func (s *separator) consumeStringContent(delim string, raw bool) {
 	for i < len(s.str) {
 		// check end of string
 		switch {
-		// delimiter is `"` or `'`
+		// check single-quoted delimiter
 		case len(delim) == 1 && string(s.str[i]) == delim:
 			s.str = s.str[i+1:]
 			s.sb.WriteString(delim)
 			return
-		// delimiter is `"""` or `'''`
+		// check triple-quoted delimiter
 		case len(delim) == 3 && len(s.str) >= i+3 && string(s.str[i:i+3]) == delim:
 			s.str = s.str[i+3:]
 			s.sb.WriteString(delim)
@@ -152,6 +152,11 @@ func (s *separator) separate() []inputStatement {
 				s.sb.WriteRune(s.str[0])
 				s.str = s.str[1:]
 			}
+		// quoted identifier
+		case '`':
+			s.sb.WriteRune(s.str[0])
+			s.str = s.str[1:]
+			s.consumeStringContent("`", false)
 		// horizontal delimiter
 		case ';':
 			statements = append(statements, inputStatement{

--- a/separator.go
+++ b/separator.go
@@ -4,6 +4,10 @@ import (
 	"strings"
 )
 
+func separateInput(input string) []inputStatement {
+	return newSeparator(input).separate()
+}
+
 type separator struct {
 	str []rune // remaining input
 	sb  *strings.Builder

--- a/separator.go
+++ b/separator.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"log"
+	"strings"
+)
+
+type separator struct {
+	str []rune // remaining input
+	sb  *strings.Builder
+}
+
+func newSeparator(s string) *separator {
+	return &separator{
+		str: []rune(s),
+		sb:  &strings.Builder{},
+	}
+}
+
+func (s *separator) consumeRawString() {
+	// consume 'r' or 'R'
+	s.sb.WriteRune(s.str[0])
+	s.str = s.str[1:]
+
+	delim := s.consumeStringDelimiter()
+	s.consumeStringContent(delim, false)
+}
+
+func (s *separator) consumeString() {
+	delim := s.consumeStringDelimiter()
+	s.consumeStringContent(delim, false)
+}
+
+func (s *separator) consumeStringContent(delim string, raw bool) error {
+	var i int
+	for i < len(s.str) {
+		if strings.HasPrefix(string(s.str[i:]), delim) {
+			log.Printf("close: remained %s", string(s.str))
+			i += len(delim)
+			s.str = s.str[i:]
+			log.Printf("after close: remained %s", string(s.str))
+			s.sb.WriteString(delim)
+			return nil
+		}
+
+		// escape character
+		if s.str[i] == '\\' {
+			i++
+			if i >= len(s.str) {
+				// TODO
+			}
+
+			if raw {
+				// raw string treats escape character as backslash
+				s.sb.WriteRune('\\')
+				i++
+				continue
+			}
+
+			s.sb.WriteRune('"')
+			i++
+			continue
+		}
+		s.sb.WriteRune(s.str[i])
+		i++
+	}
+	return nil
+}
+
+func (s *separator) consumeStringDelimiter() string {
+	c := s.str[0]
+	if len(s.str) >= 3 && s.str[1] == c && s.str[2] == c {
+		delim := strings.Repeat(string(c), 3)
+		s.sb.WriteString(delim)
+		s.str = s.str[3:]
+		return delim
+	}
+	s.str = s.str[1:]
+	s.sb.WriteRune(c)
+	return string(c)
+}
+
+// separate separates input string into multiple Spanner statements.
+//
+// Logic for parsing a statement is mostly taken from spansql.
+// https://github.com/googleapis/google-cloud-go/blob/master/spanner/spansql/parser.go
+func (s *separator) separate() ([]inputStatement, error) {
+	var statements []inputStatement
+	for len(s.str) > 0 {
+		switch s.str[0] {
+		// string literal
+		case '"', '\'', 'r', 'R', 'b', 'B':
+			// valid prefix: "b", "B", "r", "R", "br", "bR", "Br", "BR"
+			raw := false
+			for i := 0; i < 3 && i < len(s.str); i++ {
+				switch {
+				case !raw && (s.str[i] == 'r' || s.str[i] == 'R'):
+					raw = true
+					continue
+				case s.str[i] == '"' || s.str[i] == '\'':
+					if raw {
+						s.consumeRawString()
+					} else {
+						s.consumeString()
+						log.Printf("consumed: remained %s", string(s.str))
+					}
+				default:
+					s.sb.WriteRune(s.str[0])
+					s.str = s.str[1:]
+				}
+				break
+			}
+		case ';':
+			log.Printf("delimiter found: remained %s", string(s.str))
+			statements = append(statements, inputStatement{
+				statement: strings.TrimSpace(s.sb.String()),
+				delimiter: delimiterHorizontal,
+			})
+			s.sb.Reset()
+			s.str = s.str[1:]
+		case '\\':
+			if strings.HasPrefix(string(s.str), `\G`) {
+				statements = append(statements, inputStatement{
+					statement: strings.TrimSpace(s.sb.String()),
+					delimiter: delimiterVertical,
+				})
+				s.sb.Reset()
+				s.str = s.str[2:]
+			} else {
+				// TODO
+			}
+		default:
+			s.sb.WriteRune(s.str[0])
+			s.str = s.str[1:]
+		}
+	}
+
+	if s.sb.Len() > 0 {
+		// flush remained
+		statements = append(statements, inputStatement{
+			statement: strings.TrimSpace(s.sb.String()),
+			delimiter: delimiterHorizontal,
+		})
+		s.sb.Reset()
+	}
+	return statements, nil
+}

--- a/separator_test.go
+++ b/separator_test.go
@@ -205,7 +205,21 @@ func TestSeparator(t *testing.T) {
 			},
 		},
 		{
-			desc: `second query ends with middle of string`,
+			desc: `query has new line just before delimiter`,
+			input: "SELECT '123'\n; SELECT '456'\n\\G",
+			want: []inputStatement{
+				{
+					statement: `SELECT '123'`,
+					delimiter: delimiterHorizontal,
+				},
+				{
+					statement: `SELECT '456'`,
+					delimiter: delimiterVertical,
+				},
+			},
+		},
+		{
+			desc: `second query ends in the middle of string`,
 			input: `SELECT "123"; SELECT "45`,
 			want: []inputStatement{
 				{

--- a/separator_test.go
+++ b/separator_test.go
@@ -268,7 +268,7 @@ func TestSeparator(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			got := newSeparator(tt.input).separate()
+			got := separateInput(tt.input)
 			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(inputStatement{})); diff != "" {
 				t.Errorf("difference in statements: (-want +got):\n%s", diff)
 			}

--- a/separator_test.go
+++ b/separator_test.go
@@ -107,6 +107,20 @@ func TestSeparator(t *testing.T) {
 			},
 		},
 		{
+			desc: "quoted identifier",
+			input: "SELECT `1`, `2`; SELECT `3`, `4`;",
+			want: []inputStatement{
+				{
+					statement: "SELECT `1`, `2`",
+					delimiter: delimiterHorizontal,
+				},
+				{
+					statement: "SELECT `3`, `4`",
+					delimiter: delimiterHorizontal,
+				},
+			},
+		},
+		{
 			desc: "vertical delimiter",
 			input: `SELECT "123"\G`,
 			want: []inputStatement{
@@ -201,6 +215,20 @@ func TestSeparator(t *testing.T) {
 				{
 					statement: `SELECT r'4\G5\G6'`,
 					delimiter: delimiterVertical,
+				},
+			},
+		},
+		{
+			desc: "delimiter in quoted identifier",
+			input: "SELECT `1;2`; SELECT `3;4`;",
+			want: []inputStatement{
+				{
+					statement: "SELECT `1;2`",
+					delimiter: delimiterHorizontal,
+				},
+				{
+					statement: "SELECT `3;4`",
+					delimiter: delimiterHorizontal,
 				},
 			},
 		},

--- a/separator_test.go
+++ b/separator_test.go
@@ -163,6 +163,20 @@ func TestSeparator(t *testing.T) {
 			},
 		},
 		{
+			desc: "new line just after delimiter",
+			input: "SELECT 1;\n SELECT 2\\G\n",
+			want: []inputStatement{
+				{
+					statement: `SELECT 1`,
+					delimiter: delimiterHorizontal,
+				},
+				{
+					statement: `SELECT 2`,
+					delimiter: delimiterVertical,
+				},
+			},
+		},
+		{
 			desc: "horizontal delimiter in string",
 			input: `SELECT "1;2;3"; SELECT 'TL;DR';`,
 			want: []inputStatement{
@@ -228,6 +242,16 @@ func TestSeparator(t *testing.T) {
 				},
 				{
 					statement: `SELECT "45`,
+					delimiter: delimiterHorizontal,
+				},
+			},
+		},
+		{
+			desc: `DDL`,
+			input: "CREATE t1 (\nId INT64 NOT NULL\n) PRIMARY KEY (Id);",
+			want: []inputStatement{
+				{
+					statement: "CREATE t1 (\nId INT64 NOT NULL\n) PRIMARY KEY (Id)",
 					delimiter: delimiterHorizontal,
 				},
 			},

--- a/separator_test.go
+++ b/separator_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSeparator(t *testing.T) {
+	for _, tt := range []struct {
+		desc  string
+		input string
+		want  []inputStatement
+	}{
+		{
+			input: `SELECT "123";`,
+			want: []inputStatement{
+				{
+					statement: `SELECT "123"`,
+					delimiter: delimiterHorizontal,
+				},
+			},
+		},
+		{
+			input: `SELECT "123"; SELECT "456";`,
+			want: []inputStatement{
+				{
+					statement: `SELECT "123"`,
+					delimiter: delimiterHorizontal,
+				},
+				{
+					statement: `SELECT "456"`,
+					delimiter: delimiterHorizontal,
+				},
+			},
+		},
+		{
+			input: `SELECT """123"""; SELECT '''456''';`,
+			want: []inputStatement{
+				{
+					statement: `SELECT """123"""`,
+					delimiter: delimiterHorizontal,
+				},
+				{
+					statement: `SELECT '''456'''`,
+					delimiter: delimiterHorizontal,
+				},
+			},
+		},
+		{
+			input: `SELECT r"123"; SELECT R"456";`,
+			want: []inputStatement{
+				{
+					statement: `SELECT r"123"`,
+					delimiter: delimiterHorizontal,
+				},
+				{
+					statement: `SELECT R"456"`,
+					delimiter: delimiterHorizontal,
+				},
+			},
+		},
+		{
+			input: `SELECT "123"\G`,
+			want: []inputStatement{
+				{
+					statement: `SELECT "123"`,
+					delimiter: delimiterVertical,
+				},
+			},
+		},
+	} {
+		s := newSeparator(tt.input)
+		got, err := s.separate()
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		t.Logf("got:\n%#v, want:\n%#v", got, tt.want)
+
+		if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(inputStatement{})); diff != "" {
+			t.Errorf("difference in statements: (-want +got):\n%s", diff)
+		}
+	}
+}

--- a/separator_test.go
+++ b/separator_test.go
@@ -233,15 +233,15 @@ func TestSeparator(t *testing.T) {
 			},
 		},
 		{
-			desc: `second query ends in the middle of string`,
-			input: `SELECT "123"; SELECT "45`,
+			desc: `escaped quote in string`,
+			input: `SELECT "1\"2\"3"; SELECT '4\'5\'6'`,
 			want: []inputStatement{
 				{
-					statement: `SELECT "123"`,
+					statement: `SELECT "1\"2\"3"`,
 					delimiter: delimiterHorizontal,
 				},
 				{
-					statement: `SELECT "45`,
+					statement: `SELECT '4\'5\'6'`,
 					delimiter: delimiterHorizontal,
 				},
 			},
@@ -252,6 +252,20 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: "CREATE t1 (\nId INT64 NOT NULL\n) PRIMARY KEY (Id)",
+					delimiter: delimiterHorizontal,
+				},
+			},
+		},
+		{
+			desc: `second query ends in the middle of string`,
+			input: `SELECT "123"; SELECT "45`,
+			want: []inputStatement{
+				{
+					statement: `SELECT "123"`,
+					delimiter: delimiterHorizontal,
+				},
+				{
+					statement: `SELECT "45`,
 					delimiter: delimiterHorizontal,
 				},
 			},

--- a/separator_test.go
+++ b/separator_test.go
@@ -18,7 +18,7 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: `SELECT "123"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
@@ -28,11 +28,11 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: `SELECT "123"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT "456"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
@@ -42,11 +42,11 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: `SELECT """123"""`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT '''456'''`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
@@ -56,11 +56,11 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: "SELECT \"\"\"1\n2\n3\"\"\"",
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: "SELECT '''4\n5\n6'''",
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
@@ -70,11 +70,11 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: `SELECT r"123\a\n"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT R"456\\"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
@@ -84,11 +84,11 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: `SELECT b"123"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT b'\x12\x34'`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
@@ -98,11 +98,11 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: `SELECT rb"123\a"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT RB'\x12\x34\a'`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
@@ -112,39 +112,39 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: "SELECT `1`, `2`",
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: "SELECT `3`, `4`",
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
 		{
-			desc: "vertical delimiter",
+			desc: "vertical delim",
 			input: `SELECT "123"\G`,
 			want: []inputStatement{
 				{
 					statement: `SELECT "123"`,
-					delimiter: delimiterVertical,
+					delim:     delimiterVertical,
 				},
 			},
 		},
 		{
-			desc: "mixed delimiter",
+			desc: "mixed delim",
 			input: `SELECT "123"; SELECT "456"\G SELECT "789";`,
 			want: []inputStatement{
 				{
 					statement: `SELECT "123"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT "456"`,
-					delimiter: delimiterVertical,
+					delim:     delimiterVertical,
 				},
 				{
 					statement: `SELECT "789"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
@@ -154,11 +154,11 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: `SELECT * FROM t1 WHERE id = "123" AND "456"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `DELETE FROM t2 WHERE true`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
@@ -168,109 +168,109 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: `SELECT 1`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: ``,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
 		{
-			desc: "new line just after delimiter",
+			desc: "new line just after delim",
 			input: "SELECT 1;\n SELECT 2\\G\n",
 			want: []inputStatement{
 				{
 					statement: `SELECT 1`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT 2`,
-					delimiter: delimiterVertical,
+					delim:     delimiterVertical,
 				},
 			},
 		},
 		{
-			desc: "horizontal delimiter in string",
+			desc: "horizontal delim in string",
 			input: `SELECT "1;2;3"; SELECT 'TL;DR';`,
 			want: []inputStatement{
 				{
 					statement: `SELECT "1;2;3"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT 'TL;DR'`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
 		{
-			desc: `vertical delimiter in string`,
+			desc: `vertical delim in string`,
 			input: `SELECT r"1\G2\G3"\G SELECT r'4\G5\G6'\G`,
 			want: []inputStatement{
 				{
 					statement: `SELECT r"1\G2\G3"`,
-					delimiter: delimiterVertical,
+					delim:     delimiterVertical,
 				},
 				{
 					statement: `SELECT r'4\G5\G6'`,
-					delimiter: delimiterVertical,
+					delim:     delimiterVertical,
 				},
 			},
 		},
 		{
-			desc: "delimiter in quoted identifier",
+			desc: "delim in quoted identifier",
 			input: "SELECT `1;2`; SELECT `3;4`;",
 			want: []inputStatement{
 				{
 					statement: "SELECT `1;2`",
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: "SELECT `3;4`",
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
 		{
 			desc: `multi-byte character in string`,
-			input: `SELECT "テスト"; SELECT '世界'`,
+			input: `SELECT "テスト"; SELECT '世界';`,
 			want: []inputStatement{
 				{
 					statement: `SELECT "テスト"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT '世界'`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
 		{
-			desc: `query has new line just before delimiter`,
+			desc: `query has new line just before delim`,
 			input: "SELECT '123'\n; SELECT '456'\n\\G",
 			want: []inputStatement{
 				{
 					statement: `SELECT '123'`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT '456'`,
-					delimiter: delimiterVertical,
+					delim:     delimiterVertical,
 				},
 			},
 		},
 		{
 			desc: `escaped quote in string`,
-			input: `SELECT "1\"2\"3"; SELECT '4\'5\'6'`,
+			input: `SELECT "1\"2\"3"; SELECT '4\'5\'6';`,
 			want: []inputStatement{
 				{
 					statement: `SELECT "1\"2\"3"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT '4\'5\'6'`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
@@ -280,7 +280,7 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: "CREATE t1 (\nId INT64 NOT NULL\n) PRIMARY KEY (Id)",
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 			},
 		},
@@ -290,21 +290,21 @@ func TestSeparator(t *testing.T) {
 			want: []inputStatement{
 				{
 					statement: `SELECT "123"`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterHorizontal,
 				},
 				{
 					statement: `SELECT "45`,
-					delimiter: delimiterHorizontal,
+					delim:     delimiterUndefined,
 				},
 			},
 		},
 		{
 			desc: `totally incorrect query`,
-			input: `a"""""""""'''''''''b;`,
+			input: `a"""""""""'''''''''b`,
 			want: []inputStatement{
 				{
-					statement: `a"""""""""'''''''''b;`,
-					delimiter: delimiterHorizontal,
+					statement: `a"""""""""'''''''''b`,
+					delim:     delimiterUndefined,
 				},
 			},
 		},

--- a/statement.go
+++ b/statement.go
@@ -586,8 +586,8 @@ const (
 
 type BeginRoStatement struct {
 	TimestampBoundType timestampBoundType
-	Staleness time.Duration
-	Timestamp time.Time
+	Staleness          time.Duration
+	Timestamp          time.Time
 }
 
 func newBeginRoStatement(input string) *BeginRoStatement {
@@ -600,13 +600,13 @@ func newBeginRoStatement(input string) *BeginRoStatement {
 	if t, err := time.Parse(time.RFC3339Nano, matched[1]); err == nil {
 		return &BeginRoStatement{
 			TimestampBoundType: readTimestamp,
-			Timestamp: t,
+			Timestamp:          t,
 		}
 	}
 	if i, err := strconv.Atoi(matched[1]); err == nil {
 		return &BeginRoStatement{
 			TimestampBoundType: exactStaleness,
-			Staleness: time.Duration(time.Duration(i) * time.Second),
+			Staleness:          time.Duration(time.Duration(i) * time.Second),
 		}
 	}
 	return nil


### PR DESCRIPTION
Reimplemented statement separator to fix https://github.com/cloudspannerecosystem/spanner-cli/issues/33.

Note: Logic for parsing a statement is mostly taken from [spansql](https://github.com/googleapis/google-cloud-go/blob/master/spanner/spansql/parser.go).

- [x] Implement byte string
- [x] Implement raw byte string
- [x] Add more tests
- [x] optimization; parsing long text is very slow
- [x] use new separator for interactive mode
- [x] support quoted identifier
- [x] support comment line for both interactive/batch mode

close https://github.com/cloudspannerecosystem/spanner-cli/issues/33