### PR TITLE
Enhance DDL Batching

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -45,6 +45,11 @@ type Cli struct {
 	Verbose    bool
 }
 
+type statementWithFlag struct {
+	Stmt     Statement
+	Vertical bool
+}
+
 var defaultClientConfig = spanner.ClientConfig{
 	NumChannels: 1,
 	SessionPoolConfig: spanner.SessionPoolConfig{
@@ -170,30 +175,14 @@ func (c *Cli) RunInteractive() int {
 }
 
 func (c *Cli) RunBatch(input string, displayTable bool) int {
-	// execute batched only if all statements are DDL statements
-	if stmts := buildDdlStatements(input); stmts != nil {
-		result, err := stmts.Execute(c.Session)
-		if err != nil {
-			c.PrintBatchError(err)
-			return exitCodeError
-		}
-
-		if displayTable {
-			c.PrintResult(result, DisplayModeTable, false)
-		} else {
-			c.PrintResult(result, DisplayModeTab, false)
-		}
-		return exitCodeSuccess
+	stmts, err := buildStatementsWithFlag(input)
+	if err != nil {
+		c.PrintBatchError(err)
+		return exitCodeError
 	}
 
-	for _, separated := range separateInput(input) {
-		stmt, err := BuildStatement(separated.statement)
-		if err != nil {
-			c.PrintBatchError(err)
-			return exitCodeError
-		}
-
-		result, err := stmt.Execute(c.Session)
+	for _, stmt := range stmts {
+		result, err := stmt.Stmt.Execute(c.Session)
 		if err != nil {
 			c.PrintBatchError(err)
 			return exitCodeError
@@ -201,12 +190,13 @@ func (c *Cli) RunBatch(input string, displayTable bool) int {
 
 		if displayTable {
 			c.PrintResult(result, DisplayModeTable, false)
-		} else if separated.delim == delimiterVertical {
+		} else if stmt.Vertical {
 			c.PrintResult(result, DisplayModeVertical, false)
 		} else {
 			c.PrintResult(result, DisplayModeTab, false)
 		}
 	}
+
 	return exitCodeSuccess
 }
 
@@ -368,20 +358,35 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool
 	}
 }
 
-// buildDdlStatements build batched statement only if all statements are DDL statements
-func buildDdlStatements(input string) Statement {
-	var ddls []string
+func buildStatementsWithFlag(input string) ([]*statementWithFlag, error) {
+	var stmts []*statementWithFlag
+	var pendingDdls []string
 	for _, separated := range separateInput(input) {
 		stmt, err := BuildStatement(separated.statement)
 		if err != nil {
-			return nil
+			return nil, err
+		}
+		if ddl, ok := stmt.(*DdlStatement); ok {
+			pendingDdls = append(pendingDdls, ddl.Ddl)
+			continue
 		}
 
-		if ddl, ok := stmt.(*DdlStatement); ok {
-			ddls = append(ddls, ddl.Ddl)
-		} else {
-			return nil
-		}
+		// Flush pending DDLs
+		stmts = append(stmts, buildStatementWithFlagFromDdls(pendingDdls)...)
+		pendingDdls = nil
+
+		stmts = append(stmts, &statementWithFlag{stmt, separated.delim == delimiterVertical})
 	}
-	return &DdlStatements{ddls}
+
+	// Flush pending DDLs
+	stmts = append(stmts, buildStatementWithFlagFromDdls(pendingDdls)...)
+
+	return stmts, nil
+}
+
+func buildStatementWithFlagFromDdls(ddls []string) []*statementWithFlag {
+	if len(ddls) == 0 {
+		return nil
+	}
+	return []*statementWithFlag{{&DdlStatements{ddls}, false}}
 }


### PR DESCRIPTION
Enhance DDL batching to support arbitrary consecutive DDL statements. 
```sql:test.sql
CREATE TABLE test1(pk INT64) PRIMARY KEY(pk);
CREATE TABLE test2(pk INT64) PRIMARY KEY(pk);
INSERT INTO test1(pk) VALUES(1);
DROP TABLE test1;
DROP TABLE test2;
```
```
$ spanner-cli -p gcpug-public-spanner -i merpay-sponsored-instance -d apstndb -f test.sql
$ gcloud spanner operations list --project=gcpug-public-spanner --instance=merpay-sponsored-instance --database=apstndb
OPERATION_ID               STATEMENTS                         DONE  @TYPE
_auto_op_a4417d436908cfd9  DROP TABLE test1                   True  UpdateDatabaseDdlMetadata
                           DROP TABLE test2
_auto_op_98bd1b7db113ea43  CREATE TABLE test1 (               True  UpdateDatabaseDdlMetadata
                             pk INT64,
                           ) PRIMARY KEY(pk)
                           CREATE TABLE test2 (
                             pk INT64,
                           ) PRIMARY KEY(pk)

```

close #38 