### PR TITLE
Enhanced ddl batching

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -381,7 +381,7 @@ func buildStatementsWithFlag(input string) ([]*statementWithFlag, error) {
 	}
 
 	// Flush pending DDLs
-	if len(pendingDdls) == 0 {
+	if len(pendingDdls) > 0 {
 		stmts = append(stmts, &statementWithFlag{&BulkDdlStatement{pendingDdls}, false})
 	}
 

--- a/cli.go
+++ b/cli.go
@@ -175,14 +175,14 @@ func (c *Cli) RunInteractive() int {
 }
 
 func (c *Cli) RunBatch(input string, displayTable bool) int {
-	stmts, err := buildCommands(input)
+	cmds, err := buildCommands(input)
 	if err != nil {
 		c.PrintBatchError(err)
 		return exitCodeError
 	}
 
-	for _, stmt := range stmts {
-		result, err := stmt.Stmt.Execute(c.Session)
+	for _, cmd := range cmds {
+		result, err := cmd.Stmt.Execute(c.Session)
 		if err != nil {
 			c.PrintBatchError(err)
 			return exitCodeError
@@ -190,7 +190,7 @@ func (c *Cli) RunBatch(input string, displayTable bool) int {
 
 		if displayTable {
 			c.PrintResult(result, DisplayModeTable, false)
-		} else if stmt.Vertical {
+		} else if cmd.Vertical {
 			c.PrintResult(result, DisplayModeVertical, false)
 		} else {
 			c.PrintResult(result, DisplayModeTab, false)

--- a/cli.go
+++ b/cli.go
@@ -372,21 +372,18 @@ func buildStatementsWithFlag(input string) ([]*statementWithFlag, error) {
 		}
 
 		// Flush pending DDLs
-		stmts = append(stmts, buildStatementWithFlagFromDdls(pendingDdls)...)
-		pendingDdls = nil
+		if len(pendingDdls) > 0 {
+			stmts = append(stmts, &statementWithFlag{&DdlStatements{pendingDdls}, false})
+			pendingDdls = nil
+		}
 
 		stmts = append(stmts, &statementWithFlag{stmt, separated.delim == delimiterVertical})
 	}
 
 	// Flush pending DDLs
-	stmts = append(stmts, buildStatementWithFlagFromDdls(pendingDdls)...)
+	if len(pendingDdls) == 0 {
+		stmts = append(stmts, &statementWithFlag{&DdlStatements{pendingDdls}, false})
+	}
 
 	return stmts, nil
-}
-
-func buildStatementWithFlagFromDdls(ddls []string) []*statementWithFlag {
-	if len(ddls) == 0 {
-		return nil
-	}
-	return []*statementWithFlag{{&DdlStatements{ddls}, false}}
 }

--- a/cli.go
+++ b/cli.go
@@ -373,7 +373,7 @@ func buildStatementsWithFlag(input string) ([]*statementWithFlag, error) {
 
 		// Flush pending DDLs
 		if len(pendingDdls) > 0 {
-			stmts = append(stmts, &statementWithFlag{&DdlStatements{pendingDdls}, false})
+			stmts = append(stmts, &statementWithFlag{&BulkDdlStatement{pendingDdls}, false})
 			pendingDdls = nil
 		}
 
@@ -382,7 +382,7 @@ func buildStatementsWithFlag(input string) ([]*statementWithFlag, error) {
 
 	// Flush pending DDLs
 	if len(pendingDdls) == 0 {
-		stmts = append(stmts, &statementWithFlag{&DdlStatements{pendingDdls}, false})
+		stmts = append(stmts, &statementWithFlag{&BulkDdlStatement{pendingDdls}, false})
 	}
 
 	return stmts, nil

--- a/cli.go
+++ b/cli.go
@@ -45,6 +45,11 @@ type Cli struct {
 	Verbose    bool
 }
 
+type statementWithFlag struct {
+	Stmt     Statement
+	Vertical bool
+}
+
 var defaultClientConfig = spanner.ClientConfig{
 	NumChannels: 1,
 	SessionPoolConfig: spanner.SessionPoolConfig{
@@ -170,30 +175,14 @@ func (c *Cli) RunInteractive() int {
 }
 
 func (c *Cli) RunBatch(input string, displayTable bool) int {
-	// execute batched only if all statements are DDL statements
-	if stmts := buildDdlStatements(input); stmts != nil {
-		result, err := stmts.Execute(c.Session)
-		if err != nil {
-			c.PrintBatchError(err)
-			return exitCodeError
-		}
-
-		if displayTable {
-			c.PrintResult(result, DisplayModeTable, false)
-		} else {
-			c.PrintResult(result, DisplayModeTab, false)
-		}
-		return exitCodeSuccess
+	stmts, err := buildStatementsWithFlag(input)
+	if err != nil {
+		c.PrintBatchError(err)
+		return exitCodeError
 	}
 
-	for _, separated := range separateInput(input) {
-		stmt, err := BuildStatement(separated.statement)
-		if err != nil {
-			c.PrintBatchError(err)
-			return exitCodeError
-		}
-
-		result, err := stmt.Execute(c.Session)
+	for _, stmt := range stmts {
+		result, err := stmt.Stmt.Execute(c.Session)
 		if err != nil {
 			c.PrintBatchError(err)
 			return exitCodeError
@@ -201,12 +190,13 @@ func (c *Cli) RunBatch(input string, displayTable bool) int {
 
 		if displayTable {
 			c.PrintResult(result, DisplayModeTable, false)
-		} else if separated.delim == delimiterVertical {
+		} else if stmt.Vertical {
 			c.PrintResult(result, DisplayModeVertical, false)
 		} else {
 			c.PrintResult(result, DisplayModeTab, false)
 		}
 	}
+
 	return exitCodeSuccess
 }
 
@@ -368,20 +358,35 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool
 	}
 }
 
-// buildDdlStatements build batched statement only if all statements are DDL statements
-func buildDdlStatements(input string) Statement {
-	var ddls []string
+func buildStatementsWithFlag(input string) ([]*statementWithFlag, error) {
+	var stmts []*statementWithFlag
+	var pendingDdls []string
 	for _, separated := range separateInput(input) {
 		stmt, err := BuildStatement(separated.statement)
 		if err != nil {
-			return nil
+			return nil, err
+		}
+		if ddl, ok := stmt.(*DdlStatement); ok {
+			pendingDdls = append(pendingDdls, ddl.Ddl)
+			continue
 		}
 
-		if ddl, ok := stmt.(*DdlStatement); ok {
-			ddls = append(ddls, ddl.Ddl)
-		} else {
-			return nil
-		}
+		// Flush pending DDLs
+		stmts = append(stmts, buildStatementWithFlagFromDdls(pendingDdls)...)
+		pendingDdls = nil
+
+		stmts = append(stmts, &statementWithFlag{stmt, separated.delim == delimiterVertical})
 	}
-	return &DdlStatements{ddls}
+
+	// Flush pending DDLs
+	stmts = append(stmts, buildStatementWithFlagFromDdls(pendingDdls)...)
+
+	return stmts, nil
+}
+
+func buildStatementWithFlagFromDdls(ddls []string) []*statementWithFlag {
+	if len(ddls) == 0 {
+		return nil
+	}
+	return []*statementWithFlag{{&DdlStatements{ddls}, false}}
 }

--- a/cli.go
+++ b/cli.go
@@ -359,7 +359,7 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, withStats bool
 }
 
 func buildCommands(input string) ([]*command, error) {
-	var stmts []*command
+	var cmds []*command
 	var pendingDdls []string
 	for _, separated := range separateInput(input) {
 		stmt, err := BuildStatement(separated.statement)
@@ -373,17 +373,17 @@ func buildCommands(input string) ([]*command, error) {
 
 		// Flush pending DDLs
 		if len(pendingDdls) > 0 {
-			stmts = append(stmts, &command{&BulkDdlStatement{pendingDdls}, false})
+			cmds = append(cmds, &command{&BulkDdlStatement{pendingDdls}, false})
 			pendingDdls = nil
 		}
 
-		stmts = append(stmts, &command{stmt, separated.delim == delimiterVertical})
+		cmds = append(cmds, &command{stmt, separated.delim == delimiterVertical})
 	}
 
 	// Flush pending DDLs
 	if len(pendingDdls) > 0 {
-		stmts = append(stmts, &command{&BulkDdlStatement{pendingDdls}, false})
+		cmds = append(cmds, &command{&BulkDdlStatement{pendingDdls}, false})
 	}
 
-	return stmts, nil
+	return cmds, nil
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -34,11 +34,19 @@ func TestBuildDdlStatements(t *testing.T) {
 				"DROP INDEX i1",
 				"DROP TABLE t1",
 			}}, false}}},
-		{`CREATE TABLE t1(pk INT64) PRIMARY KEY(pk); CREATE TABLE t2(pk INT64) PRIMARY KEY(pk); SELECT * FROM t1\G DROP TABLE t1`,
+		{`
+CREATE TABLE t1(pk INT64) PRIMARY KEY(pk);
+CREATE TABLE t2(pk INT64) PRIMARY KEY(pk);
+SELECT * FROM t1\G
+DROP TABLE t1;
+DROP TABLE t2;
+SELECT 1;
+`,
 			[]*statementWithFlag{
 				{&DdlStatements{[]string{"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)", "CREATE TABLE t2(pk INT64) PRIMARY KEY(pk)"}}, false},
 				{&SelectStatement{"SELECT * FROM t1"}, true},
-				{&DdlStatements{[]string{"DROP TABLE t1"}}, false},
+				{&DdlStatements{[]string{"DROP TABLE t1", "DROP TABLE t2"}}, false},
+				{&SelectStatement{"SELECT 1"}, false},
 			}},
 	}
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -25,9 +25,9 @@ func TestBuildDdlStatements(t *testing.T) {
 		Expected []*statementWithFlag
 	}{
 		{`SELECT * FROM t1;`, []*statementWithFlag{{&SelectStatement{"SELECT * FROM t1"}, false}}},
-		{`CREATE TABLE t1;`, []*statementWithFlag{{&DdlStatements{[]string{"CREATE TABLE t1"}}, false}}},
+		{`CREATE TABLE t1;`, []*statementWithFlag{{&BulkDdlStatement{[]string{"CREATE TABLE t1"}}, false}}},
 		{`CREATE TABLE t1(pk INT64) PRIMARY KEY(pk); ALTER TABLE t1 ADD COLUMN col INT64; CREATE INDEX i1 ON t1(col); DROP INDEX i1; DROP TABLE t1;`,
-			[]*statementWithFlag{{&DdlStatements{[]string{
+			[]*statementWithFlag{{&BulkDdlStatement{[]string{
 				"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)",
 				"ALTER TABLE t1 ADD COLUMN col INT64",
 				"CREATE INDEX i1 ON t1(col)",
@@ -41,9 +41,9 @@ func TestBuildDdlStatements(t *testing.T) {
                 DROP TABLE t2;
                 SELECT 1;`,
 			[]*statementWithFlag{
-				{&DdlStatements{[]string{"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)", "CREATE TABLE t2(pk INT64) PRIMARY KEY(pk)"}}, false},
+				{&BulkDdlStatement{[]string{"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)", "CREATE TABLE t2(pk INT64) PRIMARY KEY(pk)"}}, false},
 				{&SelectStatement{"SELECT * FROM t1"}, true},
-				{&DdlStatements{[]string{"DROP TABLE t1", "DROP TABLE t2"}}, false},
+				{&BulkDdlStatement{[]string{"DROP TABLE t1", "DROP TABLE t2"}}, false},
 				{&SelectStatement{"SELECT 1"}, false},
 			}},
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -34,14 +34,12 @@ func TestBuildDdlStatements(t *testing.T) {
 				"DROP INDEX i1",
 				"DROP TABLE t1",
 			}}, false}}},
-		{`
-CREATE TABLE t1(pk INT64) PRIMARY KEY(pk);
-CREATE TABLE t2(pk INT64) PRIMARY KEY(pk);
-SELECT * FROM t1\G
-DROP TABLE t1;
-DROP TABLE t2;
-SELECT 1;
-`,
+		{`CREATE TABLE t1(pk INT64) PRIMARY KEY(pk);
+                CREATE TABLE t2(pk INT64) PRIMARY KEY(pk);
+                SELECT * FROM t1\G
+                DROP TABLE t1;
+                DROP TABLE t2;
+                SELECT 1;`,
 			[]*statementWithFlag{
 				{&DdlStatements{[]string{"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)", "CREATE TABLE t2(pk INT64) PRIMARY KEY(pk)"}}, false},
 				{&SelectStatement{"SELECT * FROM t1"}, true},

--- a/cli_test.go
+++ b/cli_test.go
@@ -19,15 +19,15 @@ func (n *nopCloser) Close() error {
 	return nil
 }
 
-func TestBuildStatementsWithFlag(t *testing.T) {
+func TestBuildCommands(t *testing.T) {
 	tests := []struct {
 		Input    string
-		Expected []*statementWithFlag
+		Expected []*command
 	}{
-		{`SELECT * FROM t1;`, []*statementWithFlag{{&SelectStatement{"SELECT * FROM t1"}, false}}},
-		{`CREATE TABLE t1;`, []*statementWithFlag{{&BulkDdlStatement{[]string{"CREATE TABLE t1"}}, false}}},
+		{`SELECT * FROM t1;`, []*command{{&SelectStatement{"SELECT * FROM t1"}, false}}},
+		{`CREATE TABLE t1;`, []*command{{&BulkDdlStatement{[]string{"CREATE TABLE t1"}}, false}}},
 		{`CREATE TABLE t1(pk INT64) PRIMARY KEY(pk); ALTER TABLE t1 ADD COLUMN col INT64; CREATE INDEX i1 ON t1(col); DROP INDEX i1; DROP TABLE t1;`,
-			[]*statementWithFlag{{&BulkDdlStatement{[]string{
+			[]*command{{&BulkDdlStatement{[]string{
 				"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)",
 				"ALTER TABLE t1 ADD COLUMN col INT64",
 				"CREATE INDEX i1 ON t1(col)",
@@ -40,7 +40,7 @@ func TestBuildStatementsWithFlag(t *testing.T) {
                 DROP TABLE t1;
                 DROP TABLE t2;
                 SELECT 1;`,
-			[]*statementWithFlag{
+			[]*command{
 				{&BulkDdlStatement{[]string{"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)", "CREATE TABLE t2(pk INT64) PRIMARY KEY(pk)"}}, false},
 				{&SelectStatement{"SELECT * FROM t1"}, true},
 				{&BulkDdlStatement{[]string{"DROP TABLE t1", "DROP TABLE t2"}}, false},
@@ -49,7 +49,7 @@ func TestBuildStatementsWithFlag(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got, err := buildStatementsWithFlag(test.Input)
+		got, err := buildCommands(test.Input)
 		if err != nil {
 			t.Errorf("err: %v, input: %v", err, test.Input)
 		}

--- a/cli_test.go
+++ b/cli_test.go
@@ -19,7 +19,7 @@ func (n *nopCloser) Close() error {
 	return nil
 }
 
-func TestBuildDdlStatements(t *testing.T) {
+func TestBuildStatementsWithFlag(t *testing.T) {
 	tests := []struct {
 		Input    string
 		Expected []*statementWithFlag

--- a/statement.go
+++ b/statement.go
@@ -221,11 +221,11 @@ func (s *DdlStatement) Execute(session *Session) (*Result, error) {
 	return executeDdlStatements(session, []string{s.Ddl})
 }
 
-type DdlStatements struct {
+type BulkDdlStatement struct {
 	Ddls []string
 }
 
-func (s *DdlStatements) Execute(session *Session) (*Result, error) {
+func (s *BulkDdlStatement) Execute(session *Session) (*Result, error) {
 	return executeDdlStatements(session, s.Ddls)
 }
 


### PR DESCRIPTION
Enhance DDL batching to support arbitrary consecutive DDL statements. 
```sql:test.sql
CREATE TABLE test1(pk INT64) PRIMARY KEY(pk);
CREATE TABLE test2(pk INT64) PRIMARY KEY(pk);
INSERT INTO test1(pk) VALUES(1);
DROP TABLE test1;
DROP TABLE test2;
```
```
$ spanner-cli -p gcpug-public-spanner -i merpay-sponsored-instance -d apstndb -f test.sql
$ gcloud spanner operations list --project=gcpug-public-spanner --instance=merpay-sponsored-instance --database=apstndb
OPERATION_ID               STATEMENTS                         DONE  @TYPE
_auto_op_a4417d436908cfd9  DROP TABLE test1                   True  UpdateDatabaseDdlMetadata
                           DROP TABLE test2
_auto_op_98bd1b7db113ea43  CREATE TABLE test1 (               True  UpdateDatabaseDdlMetadata
                             pk INT64,
                           ) PRIMARY KEY(pk)
                           CREATE TABLE test2 (
                             pk INT64,
                           ) PRIMARY KEY(pk)

```

close #38 