### PR TITLE
DROP DATABASE statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The syntax is case-insensitive.
 | List databases | `SHOW DATABASES;` | |
 | Switch database | `USE <database>;` | |
 | Create database | `CREATE DATABSE <database>;` | |
-| Drop database |  | Not supported yet |
+| Drop database | `DROP DATABASE <database>;` | |
 | List tables | `SHOW TABLES;` | |
 | Show table schema | `SHOW CREATE TABLE <table>;` | |
 | Show columns | `SHOW COLUMNS FROM <table>;` | |

--- a/README.md
+++ b/README.md
@@ -234,7 +234,6 @@ $ PROJECT=${PROJECT_ID} INSTANCE=${INSTANCE_ID} DATABASE=${DATABASE_ID} CREDENTI
 
 ## TODO
 
-* Support `DROP DATABASE`
 * Show secondary index by "SHOW CREATE TABLE"
 
 ## Disclaimer

--- a/cli.go
+++ b/cli.go
@@ -297,7 +297,7 @@ func readInteractiveInput(rl *readline.Instance, prompt string) (*inputStatement
 		// show prompt to urge next input
 		var margin string
 		if l := len(prompt); l >= 3 {
-			margin = strings.Repeat(" ", l - 3)
+			margin = strings.Repeat(" ", l-3)
 		}
 		rl.SetPrompt(margin + "-> ")
 	}

--- a/cli.go
+++ b/cli.go
@@ -156,8 +156,7 @@ func (c *Cli) RunInteractive() int {
 				continue
 			}
 
-			msg := fmt.Sprintf("Database %q will be dropped.\nDo you want to continue?", s.DatabaseId)
-			if ok := confirm(c.OutStream, msg); !ok {
+			if !confirm(c.OutStream, fmt.Sprintf("Database %q will be dropped.\nDo you want to continue?", s.DatabaseId)) {
 				continue
 			}
 		}

--- a/cli.go
+++ b/cli.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -146,6 +148,18 @@ func (c *Cli) RunInteractive() int {
 			c.Session = newSession
 			fmt.Fprintf(c.OutStream, "Database changed")
 			continue
+		}
+
+		if s, ok := stmt.(*DropDatabaseStatement); ok {
+			if c.Session.databaseId == s.DatabaseId {
+				c.PrintInteractiveError(fmt.Errorf("database %q is currently used, it can not be dropped", s.DatabaseId))
+				continue
+			}
+
+			msg := fmt.Sprintf("Database %q will be dropped.\nDo you want to continue?", s.DatabaseId)
+			if ok := confirm(c.OutStream, msg); !ok {
+				continue
+			}
 		}
 
 		// execute
@@ -386,4 +400,21 @@ func buildCommands(input string) ([]*command, error) {
 	}
 
 	return cmds, nil
+}
+
+func confirm(out io.Writer, msg string) bool {
+	fmt.Fprintf(out, "%s [yes/no] ", msg)
+
+	s := bufio.NewScanner(os.Stdin)
+	for {
+		s.Scan()
+		switch strings.ToLower(s.Text()) {
+		case "yes":
+			return true
+		case "no":
+			return false
+		default:
+			fmt.Fprint(out, "Please answer yes or no: ")
+		}
+	}
 }

--- a/statement.go
+++ b/statement.go
@@ -223,10 +223,6 @@ type DropDatabaseStatement struct {
 }
 
 func (s *DropDatabaseStatement) Execute(session *Session) (*Result, error) {
-	if session.databaseId == s.DatabaseId {
-		return nil, fmt.Errorf("database %q is currently used, it can not be dropped", s.DatabaseId)
-	}
-
 	if err := session.adminClient.DropDatabase(session.ctx, &adminpb.DropDatabaseRequest{
 		Database: fmt.Sprintf("projects/%s/instances/%s/databases/%s", session.projectId, session.instanceId, s.DatabaseId),
 	}); err != nil {

--- a/statement.go
+++ b/statement.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/spanner"
@@ -40,6 +41,7 @@ var (
 
 	// DDL
 	createDatabaseRe = regexp.MustCompile(`(?is)^CREATE\s+DATABASE\s.+$`)
+	dropDatabaseRe   = regexp.MustCompile(`(?is)^DROP\s+DATABASE\s+(.+)$`)
 	createTableRe    = regexp.MustCompile(`(?is)^CREATE\s+TABLE\s.+$`)
 	alterTableRe     = regexp.MustCompile(`(?is)^ALTER\s+TABLE\s.+$`)
 	dropTableRe      = regexp.MustCompile(`(?is)^DROP\s+TABLE\s.+$`)
@@ -85,6 +87,9 @@ func BuildStatement(input string) (Statement, error) {
 		return &SelectStatement{Query: input}, nil
 	case createDatabaseRe.MatchString(input):
 		return &CreateDatabaseStatement{CreateStatement: input}, nil
+	case dropDatabaseRe.MatchString(input):
+		matched := dropDatabaseRe.FindStringSubmatch(input)
+		return &DropDatabaseStatement{DatabaseId: strings.Trim(matched[1], "`")}, nil
 	case createTableRe.MatchString(input):
 		return &DdlStatement{Ddl: input}, nil
 	case alterTableRe.MatchString(input):
@@ -207,6 +212,24 @@ func (s *CreateDatabaseStatement) Execute(session *Session) (*Result, error) {
 		return nil, err
 	}
 	if _, err := op.Wait(session.ctx); err != nil {
+		return nil, err
+	}
+
+	return &Result{IsMutation: true}, nil
+}
+
+type DropDatabaseStatement struct {
+	DatabaseId string
+}
+
+func (s *DropDatabaseStatement) Execute(session *Session) (*Result, error) {
+	if session.databaseId == s.DatabaseId {
+		return nil, fmt.Errorf("database %q is currently used, it can not be dropped", s.DatabaseId)
+	}
+
+	if err := session.adminClient.DropDatabase(session.ctx, &adminpb.DropDatabaseRequest{
+		Database: fmt.Sprintf("projects/%s/instances/%s/databases/%s", session.projectId, session.instanceId, s.DatabaseId),
+	}); err != nil {
 		return nil, err
 	}
 

--- a/statement_test.go
+++ b/statement_test.go
@@ -16,97 +16,107 @@ func TestBuildStatement(t *testing.T) {
 	}
 
 	// valid tests
-	for _, test := range []struct{
+	for _, test := range []struct {
 		desc          string
 		input         string
 		want          Statement
 		skipLowerCase bool
 	}{
 		{
-			desc: "SELECT statement",
+			desc:  "SELECT statement",
 			input: "SELECT * FROM t1",
-			want: &SelectStatement{Query: "SELECT * FROM t1"},
+			want:  &SelectStatement{Query: "SELECT * FROM t1"},
 		},
 		{
-			desc: "SELECT statement in multiple lines",
+			desc:  "SELECT statement in multiple lines",
 			input: "SELECT\n*\nFROM t1",
-			want: &SelectStatement{Query: "SELECT\n*\nFROM t1"},
+			want:  &SelectStatement{Query: "SELECT\n*\nFROM t1"},
 		},
 		{
-			desc: "WITH statement",
+			desc:  "WITH statement",
 			input: "WITH sub AS (SELECT 1) SELECT * FROM sub",
-			want: &SelectStatement{Query: "WITH sub AS (SELECT 1) SELECT * FROM sub"},
+			want:  &SelectStatement{Query: "WITH sub AS (SELECT 1) SELECT * FROM sub"},
 		},
 		{
 			// https://cloud.google.com/spanner/docs/query-syntax#statement-hints
-			desc: "SELECT statement with statement hint",
+			desc:  "SELECT statement with statement hint",
 			input: "@{USE_ADDITIONAL_PARALLELISM=TRUE} SELECT * FROM t1",
-			want: &SelectStatement{Query: "@{USE_ADDITIONAL_PARALLELISM=TRUE} SELECT * FROM t1"},
+			want:  &SelectStatement{Query: "@{USE_ADDITIONAL_PARALLELISM=TRUE} SELECT * FROM t1"},
 		},
 		{
-			desc: "CREATE DATABASE statement",
+			desc:  "CREATE DATABASE statement",
 			input: "CREATE DATABASE d1",
-			want: &CreateDatabaseStatement{CreateStatement: "CREATE DATABASE d1"},
+			want:  &CreateDatabaseStatement{CreateStatement: "CREATE DATABASE d1"},
 		},
 		{
-			desc: "CREATE TABLE statement",
+			desc:  "DROP DATABASE statement",
+			input: "DROP DATABASE d1",
+			want:  &DropDatabaseStatement{DatabaseId: "d1"},
+		},
+		{
+			desc:  "DROP DATABASE statement with escaped database name",
+			input: "DROP DATABASE `TABLE`",
+			want:  &DropDatabaseStatement{DatabaseId: "TABLE"},
+		},
+		{
+			desc:  "CREATE TABLE statement",
 			input: "CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY (id)",
-			want: &DdlStatement{Ddl: "CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY (id)"},
+			want:  &DdlStatement{Ddl: "CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY (id)"},
 		},
 		{
-			desc: "ALTER TABLE statement",
+			desc:  "ALTER TABLE statement",
 			input: "ALTER TABLE t1 ADD COLUMN name STRING(16) NOT NULL",
-			want: &DdlStatement{Ddl: "ALTER TABLE t1 ADD COLUMN name STRING(16) NOT NULL"},
+			want:  &DdlStatement{Ddl: "ALTER TABLE t1 ADD COLUMN name STRING(16) NOT NULL"},
 		},
 		{
-			desc: "DROP TABLE statement",
+			desc:  "DROP TABLE statement",
 			input: "DROP TABLE t1",
-			want: &DdlStatement{Ddl: "DROP TABLE t1"},
+			want:  &DdlStatement{Ddl: "DROP TABLE t1"},
 		},
 		{
-			desc: "CREATE INDEX statement",
+			desc:  "CREATE INDEX statement",
 			input: "CREATE INDEX idx_name ON t1 (name DESC)",
-			want: &DdlStatement{Ddl: "CREATE INDEX idx_name ON t1 (name DESC)"},
+			want:  &DdlStatement{Ddl: "CREATE INDEX idx_name ON t1 (name DESC)"},
 		},
 		{
-			desc: "DROP INDEX statement",
+			desc:  "DROP INDEX statement",
 			input: "DROP INDEX idx_name",
-			want: &DdlStatement{Ddl: "DROP INDEX idx_name"},
+			want:  &DdlStatement{Ddl: "DROP INDEX idx_name"},
 		},
 		{
-			desc: "INSERT statement",
+			desc:  "INSERT statement",
 			input: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')",
-			want: &DmlStatement{Dml: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')"},
+			want:  &DmlStatement{Dml: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')"},
 		},
 		{
-			desc: "UPDATE statement",
+			desc:  "UPDATE statement",
 			input: "UPDATE t1 SET name = hello WHERE id = 1",
-			want: &DmlStatement{Dml: "UPDATE t1 SET name = hello WHERE id = 1"},
+			want:  &DmlStatement{Dml: "UPDATE t1 SET name = hello WHERE id = 1"},
 		},
 		{
-			desc: "DELETE statement",
+			desc:  "DELETE statement",
 			input: "DELETE FROM t1 WHERE id = 1",
-			want: &DmlStatement{Dml: "DELETE FROM t1 WHERE id = 1"},
+			want:  &DmlStatement{Dml: "DELETE FROM t1 WHERE id = 1"},
 		},
 		{
-			desc: "BEGIN statement",
+			desc:  "BEGIN statement",
 			input: "BEGIN",
-			want: &BeginRwStatement{},
+			want:  &BeginRwStatement{},
 		},
 		{
-			desc: "BEGIN RW statement",
+			desc:  "BEGIN RW statement",
 			input: "BEGIN RW",
-			want: &BeginRwStatement{},
+			want:  &BeginRwStatement{},
 		},
 		{
-			desc: "BEGIN RO statement",
+			desc:  "BEGIN RO statement",
 			input: "BEGIN RO",
-			want: &BeginRoStatement{TimestampBoundType: strong},
+			want:  &BeginRoStatement{TimestampBoundType: strong},
 		},
 		{
-			desc: "BEGIN RO staleness statement",
+			desc:  "BEGIN RO staleness statement",
 			input: "BEGIN RO 10",
-			want: &BeginRoStatement{Staleness: time.Duration(10 * time.Second), TimestampBoundType: exactStaleness},
+			want:  &BeginRoStatement{Staleness: time.Duration(10 * time.Second), TimestampBoundType: exactStaleness},
 		},
 		{
 			desc:          "BEGIN RO read timestamp statement",
@@ -115,96 +125,96 @@ func TestBuildStatement(t *testing.T) {
 			skipLowerCase: true,
 		},
 		{
-			desc: "COMMIT statement",
+			desc:  "COMMIT statement",
 			input: "COMMIT",
-			want: &CommitStatement{},
+			want:  &CommitStatement{},
 		},
 		{
-			desc: "ROLLBACK statement",
+			desc:  "ROLLBACK statement",
 			input: "ROLLBACK",
-			want: &RollbackStatement{},
+			want:  &RollbackStatement{},
 		},
 		{
-			desc: "CLOSE statement",
+			desc:  "CLOSE statement",
 			input: "CLOSE",
-			want: &CloseStatement{},
+			want:  &CloseStatement{},
 		},
 		{
-			desc: "EXIT statement",
+			desc:  "EXIT statement",
 			input: "EXIT",
-			want: &ExitStatement{},
+			want:  &ExitStatement{},
 		},
 		{
-			desc: "USE statement",
+			desc:  "USE statement",
 			input: "USE database2",
-			want: &UseStatement{Database: "database2"},
+			want:  &UseStatement{Database: "database2"},
 		},
 		{
-			desc: "SHOW DATABASES statement",
+			desc:  "SHOW DATABASES statement",
 			input: "SHOW DATABASES",
-			want: &ShowDatabasesStatement{},
+			want:  &ShowDatabasesStatement{},
 		},
 		{
-			desc: "SHOW CREATE TABLE statement",
+			desc:  "SHOW CREATE TABLE statement",
 			input: "SHOW CREATE TABLE t1",
-			want: &ShowCreateTableStatement{Table: "t1"},
+			want:  &ShowCreateTableStatement{Table: "t1"},
 		},
 		{
-			desc: "SHOW TABLES statement",
+			desc:  "SHOW TABLES statement",
 			input: "SHOW TABLES",
-			want: &ShowTablesStatement{},
+			want:  &ShowTablesStatement{},
 		},
 		{
-			desc: "SHOW INDEX statement",
+			desc:  "SHOW INDEX statement",
 			input: "SHOW INDEX FROM t1",
-			want: &ShowIndexStatement{Table: "t1"},
+			want:  &ShowIndexStatement{Table: "t1"},
 		},
 		{
-			desc: "SHOW INDEXES statement",
+			desc:  "SHOW INDEXES statement",
 			input: "SHOW INDEXES FROM t1",
-			want: &ShowIndexStatement{Table: "t1"},
+			want:  &ShowIndexStatement{Table: "t1"},
 		},
 		{
-			desc: "SHOW KEYS statement",
+			desc:  "SHOW KEYS statement",
 			input: "SHOW KEYS FROM t1",
-			want: &ShowIndexStatement{Table: "t1"},
+			want:  &ShowIndexStatement{Table: "t1"},
 		},
 		{
-			desc: "SHOW COLUMNS statement",
+			desc:  "SHOW COLUMNS statement",
 			input: "SHOW COLUMNS FROM t1",
-			want: &ShowColumnsStatement{Table: "t1"},
+			want:  &ShowColumnsStatement{Table: "t1"},
 		},
 		{
-			desc: "EXPLAIN statement",
+			desc:  "EXPLAIN statement",
 			input: "EXPLAIN t1",
-			want: &ShowColumnsStatement{Table: "t1"},
+			want:  &ShowColumnsStatement{Table: "t1"},
 		},
 		{
-			desc: "DESCRIBE statement",
+			desc:  "DESCRIBE statement",
 			input: "DESCRIBE t1",
-			want: &ShowColumnsStatement{Table: "t1"},
+			want:  &ShowColumnsStatement{Table: "t1"},
 		},
 		{
-			desc: "DESC statement",
+			desc:  "DESC statement",
 			input: "DESC t1",
-			want: &ShowColumnsStatement{Table: "t1"},
+			want:  &ShowColumnsStatement{Table: "t1"},
 		},
 		{
-			desc: "EXPLAIN SELECT statement",
+			desc:  "EXPLAIN SELECT statement",
 			input: "EXPLAIN SELECT * FROM t1",
-			want: &ExplainStatement{Explain: "SELECT * FROM t1"},
+			want:  &ExplainStatement{Explain: "SELECT * FROM t1"},
 		},
 		{
-			desc: "DESCRIBE SELECT statement",
+			desc:  "DESCRIBE SELECT statement",
 			input: "DESCRIBE SELECT * FROM t1",
-			want: &ExplainStatement{Explain: "SELECT * FROM t1"},
+			want:  &ExplainStatement{Explain: "SELECT * FROM t1"},
 		},
 		{
-			desc: "DESC SELECT statement",
+			desc:  "DESC SELECT statement",
 			input: "DESC SELECT * FROM t1",
-			want: &ExplainStatement{Explain: "SELECT * FROM t1"},
+			want:  &ExplainStatement{Explain: "SELECT * FROM t1"},
 		},
-	}{
+	} {
 		t.Run(test.desc, func(t *testing.T) {
 			got, err := BuildStatement(test.input)
 			if err != nil {
@@ -217,7 +227,7 @@ func TestBuildStatement(t *testing.T) {
 
 		if !test.skipLowerCase {
 			input := strings.ToLower(test.input)
-			t.Run("Lower " + test.desc, func(t *testing.T) {
+			t.Run("Lower "+test.desc, func(t *testing.T) {
 				got, err := BuildStatement(input)
 				if err != nil {
 					t.Fatalf("BuildStatement(%q) got error: %v", input, err)
@@ -239,7 +249,7 @@ func TestBuildStatement(t *testing.T) {
 		{"FOO BAR"},
 		{"SELEC T FROM t1"},
 		{"SET @a = 1"},
-	}{
+	} {
 		got, err := BuildStatement(test.input)
 		if err == nil {
 			t.Errorf("BuildStatement(%q) = %#v, but want error", got, test.input)


### PR DESCRIPTION
Implemented `DROP DATABASE database_name` statement.

## Design considerations
1. Dropping database would be a dangerous operation in most of situations, so we show prompt to user to ask if we can proceed the execution.
2. Restrict users from dropping current session's database. This restriction will be eased in the future if we change current session implementation to decouple from the database.

## Example
```
spanner> DROP DATABASE test1;
Database "test1" will be dropped.
Do you want to continue? [yes/no] yes
Query OK, 0 rows affected (1.34 sec)

spanner>
```