### PR TITLE
Show query stats in verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ spanner:
   -e, --execute=    Execute SQL statement and quit.
   -f, --file=       Execute SQL statement from file and quit.
   -t, --table       Display output in table format for batch mode.
+  -v, --verbose     Display verbose output.
       --credential= Use the specific credential file
       --prompt=     Set the prompt to the specified format
 

--- a/cli.go
+++ b/cli.go
@@ -389,7 +389,7 @@ func resultLine(result *Result, verbose bool) string {
 			detail += fmt.Sprintf("cpu:       %s\n", result.Stats.CPUTime)
 		}
 		if result.Stats.RowsScanned != "" {
-			detail += fmt.Sprintf("scanned:   %s\n", result.Stats.RowsScanned)
+			detail += fmt.Sprintf("scanned:   %s rows\n", result.Stats.RowsScanned)
 		}
 		if result.Stats.OptimizerVersion != "" {
 			detail += fmt.Sprintf("optimizer: %s\n", result.Stats.OptimizerVersion)

--- a/cli.go
+++ b/cli.go
@@ -373,14 +373,15 @@ func resultLine(result *Result, verbose bool) string {
 		return fmt.Sprintf("Query OK, %d rows affected (%s)\n", result.AffectedRows, result.Stats.ElapsedTime)
 	}
 
-	var affected string
+	var set string
 	if result.AffectedRows == 0 {
-		affected = "Empty set"
+		set = "Empty set"
 	} else {
-		affected = fmt.Sprintf("%d rows in set", result.AffectedRows)
+		set = fmt.Sprintf("%d rows in set", result.AffectedRows)
 	}
 
 	if verbose {
+		// detail is aligned with max length of key (current: 9)
 		var detail string
 		if timestamp != "" {
 			detail += fmt.Sprintf("timestamp: %s\n", timestamp)
@@ -394,9 +395,9 @@ func resultLine(result *Result, verbose bool) string {
 		if result.Stats.OptimizerVersion != "" {
 			detail += fmt.Sprintf("optimizer: %s\n", result.Stats.OptimizerVersion)
 		}
-		return fmt.Sprintf("%s (%s)\n%s", affected, result.Stats.ElapsedTime, detail)
+		return fmt.Sprintf("%s (%s)\n%s", set, result.Stats.ElapsedTime, detail)
 	}
-	return fmt.Sprintf("%s (%s)\n", affected, result.Stats.ElapsedTime)
+	return fmt.Sprintf("%s (%s)\n", set, result.Stats.ElapsedTime)
 }
 
 func buildCommands(input string) ([]*command, error) {

--- a/cli_test.go
+++ b/cli_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/chzyer/readline"
 	"github.com/google/go-cmp/cmp"
@@ -203,4 +205,123 @@ bar: 4
 			t.Errorf("invalid print: expected = %s, but got = %s", expected, got)
 		}
 	})
+}
+
+func TestResultLine(t *testing.T) {
+	timestamp := "2020-04-01T15:00:00.999999999+09:00"
+	ts, err := time.Parse(time.RFC3339Nano, timestamp)
+	if err != nil {
+		t.Fatalf("unexpected time.Parse error: %v", err)
+	}
+
+	for _, tt := range []struct {
+		desc    string
+		result  *Result
+		verbose bool
+		want    string
+	}{
+		{
+			desc: "mutation in normal mode",
+			result: &Result{
+				AffectedRows: 3,
+				IsMutation:   true,
+				Stats: QueryStats{
+					ElapsedTime: "10 msec",
+				},
+			},
+			verbose: false,
+			want:    "Query OK, 3 rows affected (10 msec)\n",
+		},
+		{
+			desc: "mutation in verbose mode (timestamp exist)",
+			result: &Result{
+				AffectedRows: 3,
+				IsMutation:   true,
+				Stats: QueryStats{
+					ElapsedTime: "10 msec",
+				},
+				Timestamp: ts,
+			},
+			verbose: true,
+			want:    fmt.Sprintf("Query OK, 3 rows affected (10 msec)\ntimestamp: %s\n", timestamp),
+		},
+		{
+			desc: "mutation in verbose mode (timestamp not exist)",
+			result: &Result{
+				AffectedRows: 0,
+				IsMutation:   true,
+				Stats: QueryStats{
+					ElapsedTime: "10 msec",
+				},
+			},
+			verbose: true,
+			want:    "Query OK, 0 rows affected (10 msec)\n",
+		},
+		{
+			desc: "query in normal mode (rows exist)",
+			result: &Result{
+				AffectedRows: 3,
+				IsMutation:   false,
+				Stats: QueryStats{
+					ElapsedTime: "10 msec",
+				},
+			},
+			verbose: false,
+			want:    "3 rows in set (10 msec)\n",
+		},
+		{
+			desc: "query in normal mode (no rows exist)",
+			result: &Result{
+				AffectedRows: 0,
+				IsMutation:   false,
+				Stats: QueryStats{
+					ElapsedTime: "10 msec",
+				},
+			},
+			verbose: false,
+			want:    "Empty set (10 msec)\n",
+		},
+		{
+			desc: "query in verbose mode (all stats fields exist)",
+			result: &Result{
+				AffectedRows: 3,
+				IsMutation:   false,
+				Stats: QueryStats{
+					ElapsedTime:      "10 msec",
+					CPUTime:          "5 msec",
+					RowsScanned:      "10",
+					RowsReturned:     "3",
+					OptimizerVersion: "2",
+				},
+				Timestamp: ts,
+			},
+			verbose: true,
+			want: fmt.Sprintf(`3 rows in set (10 msec)
+timestamp: %s
+cpu:       5 msec
+scanned:   10 rows
+optimizer: 2
+`, timestamp),
+		},
+		{
+			desc: "query in verbose mode (only stats fields supported by Cloud Spanner Emulator)",
+			result: &Result{
+				AffectedRows: 3,
+				IsMutation:   false,
+				Stats: QueryStats{
+					ElapsedTime:  "10 msec",
+					RowsReturned: "3",
+				},
+				Timestamp: ts,
+			},
+			verbose: true,
+			want:    fmt.Sprintf("3 rows in set (10 msec)\ntimestamp: %s\n", timestamp),
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := resultLine(tt.result, tt.verbose); tt.want != got {
+				t.Errorf("resultLine(%v, %v) = %q, but want = %q", tt.result, tt.verbose, got, tt.want)
+			}
+		})
+	}
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -62,9 +62,9 @@ func TestBuildCommands(t *testing.T) {
 
 func TestReadInteractiveInput(t *testing.T) {
 	for _, tt := range []struct {
-		desc  string
-		input string
-		want  *inputStatement
+		desc      string
+		input     string
+		want      *inputStatement
 		wantError bool
 	}{
 		{
@@ -100,9 +100,9 @@ func TestReadInteractiveInput(t *testing.T) {
 			},
 		},
 		{
-			desc:  "multiple statements",
-			input: "SELECT 1; SELECT 2;",
-			want: nil,
+			desc:      "multiple statements",
+			input:     "SELECT 1; SELECT 2;",
+			want:      nil,
 			wantError: true,
 		},
 	} {
@@ -136,7 +136,6 @@ func TestPrintResult(t *testing.T) {
 				Row{[]string{"1", "2"}},
 				Row{[]string{"3", "4"}},
 			},
-			Stats:      Stats{},
 			IsMutation: false,
 		}
 		printResult(out, result, DisplayModeTable, false, false)
@@ -164,7 +163,6 @@ func TestPrintResult(t *testing.T) {
 				Row{[]string{"1", "2"}},
 				Row{[]string{"3", "4"}},
 			},
-			Stats:      Stats{},
 			IsMutation: false,
 		}
 		printResult(out, result, DisplayModeVertical, false, false)
@@ -192,7 +190,6 @@ bar: 4
 				Row{[]string{"1", "2"}},
 				Row{[]string{"3", "4"}},
 			},
-			Stats:      Stats{},
 			IsMutation: false,
 		}
 		printResult(out, result, DisplayModeTab, false, false)

--- a/integration_test.go
+++ b/integration_test.go
@@ -123,8 +123,8 @@ func setup(t *testing.T, ctx context.Context, dmls []string) (*Session, string, 
 
 func compareResult(t *testing.T, got *Result, expected *Result) {
 	opts := []cmp.Option{
-		cmpopts.IgnoreFields(Result{}, "Timestamp"),
 		cmpopts.IgnoreFields(Result{}, "Stats"),
+		cmpopts.IgnoreFields(Result{}, "Timestamp"),
 	}
 	if !cmp.Equal(got, expected, opts...) {
 		t.Errorf("diff: %s", cmp.Diff(got, expected, opts...))

--- a/integration_test.go
+++ b/integration_test.go
@@ -123,8 +123,8 @@ func setup(t *testing.T, ctx context.Context, dmls []string) (*Session, string, 
 
 func compareResult(t *testing.T, got *Result, expected *Result) {
 	opts := []cmp.Option{
-		cmpopts.IgnoreFields(Stats{}, "ElapsedTime"),
 		cmpopts.IgnoreFields(Result{}, "Timestamp"),
+		cmpopts.IgnoreFields(Result{}, "Stats"),
 	}
 	if !cmp.Equal(got, expected, opts...) {
 		t.Errorf("diff: %s", cmp.Diff(got, expected, opts...))
@@ -160,10 +160,8 @@ func TestSelect(t *testing.T) {
 			Row{[]string{"1", "true"}},
 			Row{[]string{"2", "false"}},
 		},
-		Stats: Stats{
-			AffectedRows: 2,
-		},
-		IsMutation: false,
+		AffectedRows: 2,
+		IsMutation:   false,
 	})
 }
 
@@ -189,10 +187,8 @@ func TestDml(t *testing.T) {
 	}
 
 	compareResult(t, result, &Result{
-		Stats: Stats{
-			AffectedRows: 2,
-		},
-		IsMutation: true,
+		AffectedRows: 2,
+		IsMutation:   true,
 	})
 
 	// check by query
@@ -247,10 +243,8 @@ func TestReadWriteTransaction(t *testing.T) {
 		}
 
 		compareResult(t, result, &Result{
-			Stats: Stats{
-				AffectedRows: 0,
-			},
-			IsMutation: true,
+			AffectedRows: 0,
+			IsMutation:   true,
 		})
 
 		// insert
@@ -265,10 +259,8 @@ func TestReadWriteTransaction(t *testing.T) {
 		}
 
 		compareResult(t, result, &Result{
-			Stats: Stats{
-				AffectedRows: 2,
-			},
-			IsMutation: true,
+			AffectedRows: 2,
+			IsMutation:   true,
 		})
 
 		// commit
@@ -283,10 +275,8 @@ func TestReadWriteTransaction(t *testing.T) {
 		}
 
 		compareResult(t, result, &Result{
-			Stats: Stats{
-				AffectedRows: 0,
-			},
-			IsMutation: true,
+			AffectedRows: 0,
+			IsMutation:   true,
 		})
 
 		// check by query
@@ -336,10 +326,8 @@ func TestReadWriteTransaction(t *testing.T) {
 		}
 
 		compareResult(t, result, &Result{
-			Stats: Stats{
-				AffectedRows: 0,
-			},
-			IsMutation: true,
+			AffectedRows: 0,
+			IsMutation:   true,
 		})
 
 		// insert
@@ -354,10 +342,8 @@ func TestReadWriteTransaction(t *testing.T) {
 		}
 
 		compareResult(t, result, &Result{
-			Stats: Stats{
-				AffectedRows: 2,
-			},
-			IsMutation: true,
+			AffectedRows: 2,
+			IsMutation:   true,
 		})
 
 		// rollback
@@ -372,10 +358,8 @@ func TestReadWriteTransaction(t *testing.T) {
 		}
 
 		compareResult(t, result, &Result{
-			Stats: Stats{
-				AffectedRows: 0,
-			},
-			IsMutation: true,
+			AffectedRows: 0,
+			IsMutation:   true,
 		})
 
 		// check by query
@@ -454,10 +438,8 @@ func TestReadOnlyTransaction(t *testing.T) {
 		}
 
 		compareResult(t, result, &Result{
-			Stats: Stats{
-				AffectedRows: 0,
-			},
-			IsMutation: true,
+			AffectedRows: 0,
+			IsMutation:   true,
 		})
 
 		// query
@@ -477,10 +459,8 @@ func TestReadOnlyTransaction(t *testing.T) {
 				Row{[]string{"1", "true"}},
 				Row{[]string{"2", "false"}},
 			},
-			Stats: Stats{
-				AffectedRows: 2,
-			},
-			IsMutation: false,
+			AffectedRows: 2,
+			IsMutation:   false,
 		})
 
 		// close
@@ -495,10 +475,8 @@ func TestReadOnlyTransaction(t *testing.T) {
 		}
 
 		compareResult(t, result, &Result{
-			Stats: Stats{
-				AffectedRows: 0,
-			},
-			IsMutation: true,
+			AffectedRows: 0,
+			IsMutation:   true,
 		})
 	})
 
@@ -552,10 +530,8 @@ func TestReadOnlyTransaction(t *testing.T) {
 				Row{[]string{"1", "true"}},
 				Row{[]string{"2", "false"}},
 			},
-			Stats: Stats{
-				AffectedRows: 2,
-			},
-			IsMutation: false,
+			AffectedRows: 2,
+			IsMutation:   false,
 		})
 
 		// close
@@ -597,9 +573,7 @@ func TestShowCreateTable(t *testing.T) {
 		Rows: []Row{
 			Row{[]string{tableId, fmt.Sprintf("CREATE TABLE %s (\n  id INT64 NOT NULL,\n  active BOOL NOT NULL,\n) PRIMARY KEY(id)", tableId)}},
 		},
-		Stats: Stats{
-			AffectedRows: 1,
-		},
-		IsMutation: false,
+		AffectedRows: 1,
+		IsMutation:   false,
 	})
 }

--- a/statement.go
+++ b/statement.go
@@ -221,7 +221,7 @@ func parseQueryResult(iter *spanner.RowIterator) ([]Row, []string, error) {
 	return rows, columnNames, nil
 }
 
-// parseQueryStats parses spanner.RowIterator.QueryStats
+// parseQueryStats parses spanner.RowIterator.QueryStats.
 func parseQueryStats(stats map[string]interface{}) QueryStats {
 	var queryStats QueryStats
 


### PR DESCRIPTION
## Stats fields

I chose following fields for display.

- elapsed (Total elapsed time)
- cpu (CPU time)
- scanned (Rows scanned)
- optimizer (Optimizer version)

These fields are equivalent to the output for `gcloud spanner databases execute-sql --query-mode=PROFILE`.

## Example

Query:
```
spanner> select * from t1;
+------+
| T1Id |
+------+
| 1    |
| 2    |
| 3    |
| 4    |
| 5    |
+------+
5 rows in set (2.69 msecs)
timestamp: 2020-04-19T13:11:03.496776+09:00
cpu:       1.11 msecs
scanned:   5 rows
optimizer: 2
```

Mutation:
```
spanner> insert into t1 (T1Id) values (6), (7), (8);
Query OK, 3 rows affected (5.42 sec)
timestamp: 2020-04-19T13:31:08.064703+09:00
```

## Other changes
Following statements used `SelectStatement` to execute query for INFORMATION SCHEMA, but it was not an ideal way since it uses user's transaction implicitly and also query stats doesn't have meaningful information.

- `SHOW TABLES`
- `SHOW COLUMNS`
- `SHOW INDEX`

So I changed to use standalone read-only transaction to execute those queries.

## TODO
- [x] Fix timestamp output for mutation result
- [x] Fix existing test
- [x] Add tests

close https://github.com/cloudspannerecosystem/spanner-cli/issues/37

---

## Example (obsolete: single line)

Query:
```
spanner> select * from t1;
+------+
| T1Id |
+------+
| 1    |
| 2    |
| 3    |
| 4    |
| 5    |
+------+
5 rows in set (elapsed: 2.89 msecs, cpu: 0.98 msecs, scanned: 5 rows, optimizer: 2, timestamp: 2020-04-18T23:43:43.728042+09:00)
```

Mutation:

```
spanner> insert into t1 (T1Id) values (6), (7), (8);
Query OK, 3 rows affected (elapsed: 1.21 sec, timestamp: 2020-04-18T23:45:22.310926+09:00)
```