### PR TITLE
Fix to support case insensitiveness in SHOW * statement

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -593,3 +593,35 @@ func TestShowCreateTable(t *testing.T) {
 		IsMutation:   false,
 	})
 }
+
+func TestShowColumns(t *testing.T) {
+	if skipIntegrateTest {
+		t.Skip("Integration tests skipped")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	session, tableId, tearDown := setup(t, ctx, []string{})
+	defer tearDown()
+
+	stmt, err := BuildStatement(fmt.Sprintf("SHOW COLUMNS FROM %s", tableId))
+	if err != nil {
+		t.Fatalf("invalid statement: error=%s", err)
+	}
+
+	result, err := stmt.Execute(session)
+	if err != nil {
+		t.Fatalf("unexpected error happened: %s", err)
+	}
+
+	compareResult(t, result, &Result{
+		ColumnNames: []string{"Field", "Type", "NULL", "Key", "Key_Order", "Options"},
+		Rows: []Row{
+			Row{[]string{"id", "INT64", "NO", "PRIMARY_KEY", "ASC", "NULL"}},
+			Row{[]string{"active", "BOOL", "NO", "NULL", "NULL", "NULL"}},
+		},
+		AffectedRows: 2,
+		IsMutation:   false,
+	})
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -62,7 +62,7 @@ func TestMain(m *testing.M) {
 }
 
 func initialize() {
-	if os.Getenv(envTestProjectId) == "" || os.Getenv(envTestInstanceId) == "" || os.Getenv(envTestDatabaseId) == "" || os.Getenv(envTestCredential) == "" {
+	if os.Getenv(envTestProjectId) == "" || os.Getenv(envTestInstanceId) == "" || os.Getenv(envTestDatabaseId) == "" {
 		skipIntegrateTest = true
 		return
 	}
@@ -79,9 +79,13 @@ func generateUniqueTableId() string {
 }
 
 func setup(t *testing.T, ctx context.Context, dmls []string) (*Session, string, func()) {
+	var options []option.ClientOption
+	if testCredential != "" {
+		options = append(options, option.WithCredentialsJSON([]byte(testCredential)))
+	}
 	session, err := NewSession(ctx, testProjectId, testInstanceId, testDatabaseId, spanner.ClientConfig{
 		SessionPoolConfig: spanner.SessionPoolConfig{WriteSessions: 0.2},
-	}, option.WithCredentialsJSON([]byte(testCredential)))
+	}, options...)
 	if err != nil {
 		t.Fatalf("failed to create test session: err=%s", err)
 	}

--- a/statement.go
+++ b/statement.go
@@ -475,9 +475,9 @@ func (s *ShowColumnsStatement) Execute(session *Session) (*Result, error) {
   C.COLUMN_NAME as Field,
   C.SPANNER_TYPE as Type,
   C.IS_NULLABLE as `+"`NULL`"+`,
-  I.INDEX_TYPE as `+"`Key`"+`,
+  I.INDEX_TYPE as Key,
   IC.COLUMN_ORDERING as Key_Order,
-  CONCAT(CO.OPTION_NAME, "=", CO.OPTION_VALUE) as `+"`Options`"+`
+  CONCAT(CO.OPTION_NAME, "=", CO.OPTION_VALUE) as Options
 FROM
   INFORMATION_SCHEMA.COLUMNS C
 LEFT JOIN

--- a/statement.go
+++ b/statement.go
@@ -99,6 +99,15 @@ var (
 	rollbackError = errors.New("rollback")
 )
 
+func firstNonEmpty(input ...string) string {
+	for _, s := range input {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
 func findStringSubmatchMap(re *regexp.Regexp, input string) map[string]string {
 	namedMatched := make(map[string]string)
 	for i, s := range re.FindStringSubmatch(input) {
@@ -145,11 +154,7 @@ func BuildStatement(input string) (Statement, error) {
 		return &ExplainStatement{Explain: matched[1]}, nil
 	case showColumnsRe.MatchString(input):
 		matched := findStringSubmatchMap(showColumnsRe, input)
-		table := matched["quoted_identifier"]
-		if table == "" {
-			table = matched["identifier"]
-		}
-		return &ShowColumnsStatement{Table: table}, nil
+		return &ShowColumnsStatement{Table: firstNonEmpty(matched["quoted_identifier"], matched["identifier"])}, nil
 	case showIndexRe.MatchString(input):
 		matched := showIndexRe.FindStringSubmatch(input)
 		return &ShowIndexStatement{Table: matched[1]}, nil

--- a/statement.go
+++ b/statement.go
@@ -481,7 +481,7 @@ func (s *ShowColumnsStatement) Execute(session *Session) (*Result, error) {
 		return nil, errors.New(`"SHOW COLUMNS" can not be used in a read-write transaction`)
 	}
 
-	stmt := spanner.NewStatement(`SELECT
+	stmt := spanner.Statement{SQL: `SELECT
   C.COLUMN_NAME as Field,
   C.SPANNER_TYPE as Type,
   C.IS_NULLABLE as ` + "`NULL`" + `,
@@ -499,9 +499,11 @@ LEFT JOIN
 WHERE
   C.TABLE_SCHEMA = '' AND (LOWER(C.TABLE_NAME) = LOWER(@table_name) OR C.TABLE_NAME = @quoted_table_name)
 ORDER BY
-  C.ORDINAL_POSITION ASC`)
-	stmt.Params["table_name"] = s.Table
-	stmt.Params["quoted_table_name"] = s.QuotedTable
+  C.ORDINAL_POSITION ASC`,
+		Params: map[string]interface{}{
+			"table_name":        s.Table,
+			"quoted_table_name": s.QuotedTable,
+		}}
 
 	var txn *spanner.ReadOnlyTransaction
 	if session.InRoTxn() {

--- a/statement.go
+++ b/statement.go
@@ -493,9 +493,7 @@ WHERE
   C.TABLE_SCHEMA = '' AND LOWER(C.TABLE_NAME) = LOWER(@table_name)
 ORDER BY
   C.ORDINAL_POSITION ASC`,
-		Params: map[string]interface{}{
-			"table_name": s.Table,
-		}}
+		Params: map[string]interface{}{"table_name": s.Table}}
 
 	var txn *spanner.ReadOnlyTransaction
 	if session.InRoTxn() {
@@ -533,7 +531,7 @@ func (s *ShowIndexStatement) Execute(session *Session) (*Result, error) {
 	}
 
 	stmt := spanner.Statement{
-		SQL:`SELECT
+		SQL: `SELECT
   TABLE_NAME as Table,
   PARENT_TABLE_NAME as Parent_table,
   INDEX_NAME as Index_name,

--- a/statement.go
+++ b/statement.go
@@ -89,7 +89,7 @@ var (
 	showDatabasesRe   = regexp.MustCompile(`(?is)^SHOW\s+DATABASES$`)
 	showCreateTableRe = regexp.MustCompile(`(?is)^SHOW\s+CREATE\s+TABLE\s+(.+)$`)
 	showTablesRe      = regexp.MustCompile(`(?is)^SHOW\s+TABLES$`)
-	showColumnsRe     = regexp.MustCompile(`(?is)^(?:SHOW\s+COLUMNS\s+FROM)\s+(?:(?:\x60(?P<quoted_identifier>.*)\x60)|(?P<identifier>.+))$`)
+	showColumnsRe     = regexp.MustCompile(`(?is)^(?:SHOW\s+COLUMNS\s+FROM)\s+(?:\x60(?P<quoted_identifier>.*)\x60|(?P<identifier>.+))$`)
 	showIndexRe       = regexp.MustCompile(`(?is)^SHOW\s+(?:INDEX|INDEXES|KEYS)\s+FROM\s+(.+)$`)
 	explainRe         = regexp.MustCompile(`(?is)^(?:EXPLAIN|DESC(?:RIBE)?)\s+((?:WITH|@{.+|SELECT)\s+.+)$`)
 )

--- a/statement_test.go
+++ b/statement_test.go
@@ -90,11 +90,6 @@ func TestBuildStatement(t *testing.T) {
 			want:  &DdlStatement{Ddl: "DROP TABLE t1"},
 		},
 		{
-			desc:  "DROP TABLE statement",
-			input: "DROP TABLE t1",
-			want:  &DdlStatement{Ddl: "DROP TABLE t1"},
-		},
-		{
 			desc:  "CREATE INDEX statement",
 			input: "CREATE INDEX idx_name ON t1 (name DESC)",
 			want:  &DdlStatement{Ddl: "CREATE INDEX idx_name ON t1 (name DESC)"},

--- a/statement_test.go
+++ b/statement_test.go
@@ -201,6 +201,11 @@ func TestBuildStatement(t *testing.T) {
 			want:  &ShowColumnsStatement{Table: "t1"},
 		},
 		{
+			desc:  "SHOW COLUMNS statement with quoted identifier",
+			input: "SHOW COLUMNS FROM `t1`",
+			want:  &ShowColumnsStatement{QuotedTable: "t1"},
+		},
+		{
 			desc:  "EXPLAIN SELECT statement",
 			input: "EXPLAIN SELECT * FROM t1",
 			want:  &ExplainStatement{Explain: "SELECT * FROM t1"},

--- a/statement_test.go
+++ b/statement_test.go
@@ -203,7 +203,7 @@ func TestBuildStatement(t *testing.T) {
 		{
 			desc:  "SHOW COLUMNS statement with quoted identifier",
 			input: "SHOW COLUMNS FROM `t1`",
-			want:  &ShowColumnsStatement{QuotedTable: "t1"},
+			want:  &ShowColumnsStatement{Table: "t1"},
 		},
 		{
 			desc:  "EXPLAIN SELECT statement",

--- a/statement_test.go
+++ b/statement_test.go
@@ -90,6 +90,11 @@ func TestBuildStatement(t *testing.T) {
 			want:  &DdlStatement{Ddl: "DROP TABLE t1"},
 		},
 		{
+			desc:  "DROP TABLE statement",
+			input: "DROP TABLE t1",
+			want:  &DdlStatement{Ddl: "DROP TABLE t1"},
+		},
+		{
 			desc:  "CREATE INDEX statement",
 			input: "CREATE INDEX idx_name ON t1 (name DESC)",
 			want:  &DdlStatement{Ddl: "CREATE INDEX idx_name ON t1 (name DESC)"},
@@ -176,9 +181,9 @@ func TestBuildStatement(t *testing.T) {
 			want:  &ShowCreateTableStatement{Table: "t1"},
 		},
 		{
-			desc:  "SHOW CREATE TABLE statement",
-			input: "SHOW CREATE TABLE `t1`",
-			want:  &ShowCreateTableStatement{Table: "t1"},
+			desc:  "SHOW CREATE TABLE statement with quoted identifier",
+			input: "SHOW CREATE TABLE `TABLE`",
+			want:  &ShowCreateTableStatement{Table: "TABLE"},
 		},
 		{
 			desc:  "SHOW TABLES statement",
@@ -197,8 +202,8 @@ func TestBuildStatement(t *testing.T) {
 		},
 		{
 			desc:  "SHOW INDEX statement with quoted identifier",
-			input: "SHOW INDEX FROM `t1`",
-			want:  &ShowIndexStatement{Table: "t1"},
+			input: "SHOW INDEX FROM `TABLE`",
+			want:  &ShowIndexStatement{Table: "TABLE"},
 		},
 		{
 			desc:  "SHOW KEYS statement",
@@ -212,8 +217,8 @@ func TestBuildStatement(t *testing.T) {
 		},
 		{
 			desc:  "SHOW COLUMNS statement with quoted identifier",
-			input: "SHOW COLUMNS FROM `t1`",
-			want:  &ShowColumnsStatement{Table: "t1"},
+			input: "SHOW COLUMNS FROM `TABLE`",
+			want:  &ShowColumnsStatement{Table: "TABLE"},
 		},
 		{
 			desc:  "EXPLAIN SELECT statement",

--- a/statement_test.go
+++ b/statement_test.go
@@ -191,6 +191,11 @@ func TestBuildStatement(t *testing.T) {
 			want:  &ShowIndexStatement{Table: "t1"},
 		},
 		{
+			desc:  "SHOW INDEX statement with quoted identifier",
+			input: "SHOW INDEX FROM `t1`",
+			want:  &ShowIndexStatement{Table: "t1"},
+		},
+		{
 			desc:  "SHOW KEYS statement",
 			input: "SHOW KEYS FROM t1",
 			want:  &ShowIndexStatement{Table: "t1"},

--- a/statement_test.go
+++ b/statement_test.go
@@ -176,6 +176,11 @@ func TestBuildStatement(t *testing.T) {
 			want:  &ShowCreateTableStatement{Table: "t1"},
 		},
 		{
+			desc:  "SHOW CREATE TABLE statement",
+			input: "SHOW CREATE TABLE `t1`",
+			want:  &ShowCreateTableStatement{Table: "t1"},
+		},
+		{
 			desc:  "SHOW TABLES statement",
 			input: "SHOW TABLES",
 			want:  &ShowTablesStatement{},


### PR DESCRIPTION
Support quoted identifier and case-insensitive in `SHOW COLUMNS`, `SHOW INDEX`, `SHOW CREATE TABLE` statement.
It also changes:
* ~~Begin to use named capture groups because pattern become more complicated~~
* Add integration test of `SHOW COLUMNS`
* `integration_test.go` uses ADC when `SPANNER_CLI_INTEGRATION_TEST_CREDENTIAL` is not specified
  * Talked in https://github.com/cloudspannerecosystem/spanner-cli/pull/32#pullrequestreview-384552221

refs #48