### PR TITLE
Improve local integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/yfuruyama/spanner-cli
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.14
         environment:
           GO111MODULE: "on"
       - image: gcr.io/cloud-spanner-emulator/emulator:0.7.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,8 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/yfuruyama/spanner-cli
     docker:
       - image: circleci/golang:1.14
-        environment:
-          GO111MODULE: "on"
       - image: gcr.io/cloud-spanner-emulator/emulator:0.7.3
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ Run integration tests, which connects to real Cloud Spanner database.
 $ PROJECT=${PROJECT_ID} INSTANCE=${INSTANCE_ID} DATABASE=${DATABASE_ID} CREDENTIAL=${CREDENTIAL} make test
 ```
 
+Run integration tests in [CircleCI Local CLI](https://circleci.com/docs/2.0/local-cli/), which connects to [Cloud Spanner Emulator}(https://cloud.google.com/spanner/docs/emulator?hl=en)
+
+```
+$ circleci local execute
+```
+
 ## TODO
 
 * Show secondary index by "SHOW CREATE TABLE"

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Run integration tests, which connects to real Cloud Spanner database.
 $ PROJECT=${PROJECT_ID} INSTANCE=${INSTANCE_ID} DATABASE=${DATABASE_ID} CREDENTIAL=${CREDENTIAL} make test
 ```
 
-Run integration tests in [CircleCI Local CLI](https://circleci.com/docs/2.0/local-cli/), which connects to [Cloud Spanner Emulator}(https://cloud.google.com/spanner/docs/emulator?hl=en)
+Run integration tests in [CircleCI Local CLI](https://circleci.com/docs/2.0/local-cli/), which connects to [Cloud Spanner Emulator](https://cloud.google.com/spanner/docs/emulator?hl=en)
 
 ```
 $ circleci local execute

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Run integration tests, which connects to real Cloud Spanner database.
 $ PROJECT=${PROJECT_ID} INSTANCE=${INSTANCE_ID} DATABASE=${DATABASE_ID} CREDENTIAL=${CREDENTIAL} make test
 ```
 
-Run integration tests in [CircleCI Local CLI](https://circleci.com/docs/2.0/local-cli/), which connects to [Cloud Spanner Emulator](https://cloud.google.com/spanner/docs/emulator?hl=en)
+Run integration tests in [CircleCI Local CLI](https://circleci.com/docs/2.0/local-cli/), which connects to [Cloud Spanner Emulator](https://cloud.google.com/spanner/docs/emulator?hl=en).
 
 ```
 $ circleci local execute


### PR DESCRIPTION
Add description of how to run integration tests with Cloud Spanner Emulator in local.
Additionally,
* Update `circleci/golang` image for:
  * Improve `go mod download` speed by GOPROXY
    * before [1m](https://app.circleci.com/pipelines/github/cloudspannerecosystem/spanner-cli/159/workflows/54998da1-2176-4b3e-ab2d-6c15b5b7b1fe/jobs/162/steps), after [4s](https://app.circleci.com/jobs/github/cloudspannerecosystem/spanner-cli/163) w/o caches
  * Simplify `.circleci/config.yml` because Go module-mode is now default