### PR TITLE
Unquote database name for USE statement

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -105,7 +105,7 @@ func BuildStatement(input string) (Statement, error) {
 		return &ExitStatement{}, nil
 	case useRe.MatchString(input):
 		matched := useRe.FindStringSubmatch(input)
-		return &UseStatement{Database: matched[1]}, nil
+		return &UseStatement{Database: unquoteIdentifier(matched[1])}, nil
 	case selectRe.MatchString(input):
 		return &SelectStatement{Query: input}, nil
 	case createDatabaseRe.MatchString(input):

--- a/statement_test.go
+++ b/statement_test.go
@@ -166,6 +166,11 @@ func TestBuildStatement(t *testing.T) {
 			want:  &UseStatement{Database: "database2"},
 		},
 		{
+			desc:  "USE statement with quoted identifier",
+			input: "USE `my-database`",
+			want:  &UseStatement{Database: "my-database"},
+		},
+		{
 			desc:  "SHOW DATABASES statement",
 			input: "SHOW DATABASES",
 			want:  &ShowDatabasesStatement{},


### PR DESCRIPTION
Without unquoting, quote ("`") is handled as a part of database name.
```
spanner> use `test`;
ERROR: ERROR: Unknown database "`test`"
```