### PR TITLE
setting `-p -i -d` with environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Usage:
   spanner-cli [OPTIONS]
 
 spanner:
-  -p, --project=    (required) GCP Project ID.
-  -i, --instance=   (required) Cloud Spanner Instance ID
-  -d, --database=   (required) Cloud Spanner Database ID.
+  -p, --project=    (required) GCP Project ID. [$SPANNER_PROJECT_ID]
+  -i, --instance=   (required) Cloud Spanner Instance ID [$SPANNER_INSTANCE_ID]
+  -d, --database=   (required) Cloud Spanner Database ID. [$SPANNER_DATABASE_ID]
   -e, --execute=    Execute SQL statement and quit.
   -f, --file=       Execute SQL statement from file and quit.
   -t, --table       Display output in table format for batch mode.

--- a/main.go
+++ b/main.go
@@ -32,9 +32,9 @@ type globalOptions struct {
 }
 
 type spannerOptions struct {
-	ProjectId  string `short:"p" long:"project" description:"(required) GCP Project ID."`
-	InstanceId string `short:"i" long:"instance" description:"(required) Cloud Spanner Instance ID"`
-	DatabaseId string `short:"d" long:"database" description:"(required) Cloud Spanner Database ID."`
+	ProjectId  string `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
+	InstanceId string `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID"`
+	DatabaseId string `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
 	Execute    string `short:"e" long:"execute" description:"Execute SQL statement and quit."`
 	File       string `short:"f" long:"file" description:"Execute SQL statement from file and quit."`
 	Table      bool   `short:"t" long:"table" description:"Display output in table format for batch mode."`


### PR DESCRIPTION
Hi, thank you for your awesome project!

This PR sets `-p -i -d` with environment variables as well as flags. I think, for many people setting those flags every single operation is painful and easy to make mistakes.

I picked env names below since many toolchains in spanner-ecosystems something like `handy-spanner` and `wrench` already adopt those names. If `spanner-cli` adopt them, I think it would be comfortable.

```
SPANNER_PROJECT_ID
SPANNER_INSTANCE_ID
SPANNER_DATABASE_ID
```