### PR TITLE
Display child type in EXPLAIN statements

### DIFF
--- a/query_plan.go
+++ b/query_plan.go
@@ -24,9 +24,14 @@ import (
 	pb "google.golang.org/genproto/googleapis/spanner/v1"
 )
 
+type Link struct {
+	Dest *Node
+	Type string
+}
+
 type Node struct {
 	PlanNode *pb.PlanNode
-	Children []*Node
+	Children []*Link
 }
 
 func BuildQueryPlanTree(plan *pb.QueryPlan, idx int32) *Node {
@@ -41,13 +46,19 @@ func BuildQueryPlanTree(plan *pb.QueryPlan, idx int32) *Node {
 
 	root := &Node{
 		PlanNode: plan.PlanNodes[idx],
-		Children: make([]*Node, 0),
+		Children: make([]*Link, 0),
 	}
 	if root.PlanNode.ChildLinks != nil {
-		for _, childLink := range root.PlanNode.ChildLinks {
+		for i, childLink := range root.PlanNode.ChildLinks {
 			idx := childLink.ChildIndex
 			child := BuildQueryPlanTree(plan, idx)
-			root.Children = append(root.Children, child)
+			childType := childLink.Type
+
+			// Fill missing Input type into the first child of [Distributed] Cross Apply
+			if childType == "" && strings.HasSuffix(root.PlanNode.DisplayName, "Cross Apply") && i == 0 {
+				childType = "Input"
+			}
+			root.Children = append(root.Children, &Link{Type: childType, Dest: child})
 		}
 	}
 
@@ -56,7 +67,7 @@ func BuildQueryPlanTree(plan *pb.QueryPlan, idx int32) *Node {
 
 func (n *Node) Render() string {
 	tree := treeprint.New()
-	renderTree(tree, n)
+	renderTree(tree, "", n)
 	return "\n" + tree.String()
 }
 
@@ -98,7 +109,7 @@ func getAllMetadataString(node *Node) string {
 	return fmt.Sprintf(`(%s)`, strings.Join(fields, ", "))
 }
 
-func renderTree(tree treeprint.Tree, node *Node) {
+func renderTree(tree treeprint.Tree, linkType string, node *Node) {
 	if !node.IsVisible() {
 		return
 	}
@@ -106,11 +117,20 @@ func renderTree(tree treeprint.Tree, node *Node) {
 	str := node.String()
 
 	if len(node.Children) > 0 {
-		branch := tree.AddBranch(str)
+		var branch treeprint.Tree
+		if linkType != "" {
+			branch = tree.AddMetaBranch(linkType, str)
+		} else {
+			branch = tree.AddBranch(str)
+		}
 		for _, child := range node.Children {
-			renderTree(branch, child)
+			renderTree(branch, child.Type, child.Dest)
 		}
 	} else {
-		tree.AddNode(str)
+		if linkType != "" {
+			tree.AddMetaNode(linkType, str)
+		} else {
+			tree.AddNode(str)
+		}
 	}
 }

--- a/query_plan.go
+++ b/query_plan.go
@@ -54,8 +54,8 @@ func BuildQueryPlanTree(plan *pb.QueryPlan, idx int32) *Node {
 			child := BuildQueryPlanTree(plan, idx)
 			childType := childLink.Type
 
-			// Fill missing Input type into the first child of [Distributed] Cross Apply
-			if childType == "" && strings.HasSuffix(root.PlanNode.DisplayName, "Cross Apply") && i == 0 {
+			// Fill missing Input type into the first child of [Distributed] (Cross|Outer) Apply
+			if childType == "" && strings.HasSuffix(root.PlanNode.DisplayName, "Apply") && i == 0 {
 				childType = "Input"
 			}
 			root.Children = append(root.Children, &Link{Type: childType, Dest: child})


### PR DESCRIPTION
Display child type in `EXPLAIN` statements.

## Examples

The followings are examples of query plans for queries in [Query execution operators](https://cloud.google.com/spanner/docs/query-execution-operators?hl=en) document.

### [Distributed Cross Apply](https://cloud.google.com/spanner/docs/query-execution-operators?hl=en#distributed-cross-apply)

```
Query_Execution_Plan (EXPERIMENTAL)

.
└── Distributed Union (subquery_cluster_node: 1)
    └── Distributed Cross Apply (subquery_cluster_node: 9)
        ├── [Input]  Create Batch 
        │   └── Distributed Union (call_type: Local, subquery_cluster_node: 4)
        │       └── Compute Struct 
        │           └── Scan (scan_type: IndexScan, scan_target: SongsBySingerAlbumSongNameDesc, Full scan: true)
        └── [Map]  Serialize Result 
            └── Cross Apply 
                ├── [Input]  Scan (scan_target: $v2, scan_type: BatchScan)
                └── [Map]  Distributed Union (subquery_cluster_node: 14, call_type: Local)
                    └── FilterScan 
                        └── Scan (scan_target: AlbumsByAlbumTitle, Full scan: true, scan_type: IndexScan)

```

### [Hash Join](https://cloud.google.com/spanner/docs/query-execution-operators?hl=en#hash-join)

```
Query_Execution_Plan (EXPERIMENTAL)

.
└── Distributed Union (subquery_cluster_node: 1)
    └── Serialize Result 
        └── Hash Join (join_type: INNER)
            ├── [Build]  Distributed Union (subquery_cluster_node: 4, call_type: Local)
            │   └── Scan (Full scan: true, scan_type: TableScan, scan_target: Albums)
            └── [Probe]  Distributed Union (call_type: Local, subquery_cluster_node: 9)
                └── Scan (scan_type: IndexScan, scan_target: SongsBySingerAlbumSongNameDesc, Full scan: true)
```

### [Distributed Outer Apply](https://cloud.google.com/spanner/docs/query-execution-operators?hl=en#distributed-outer-apply)

Example query in the document seems wrong so I have written an alternative query.

```
EXPLAIN SELECT AlbumTitle, SongName FROM Albums
LEFT OUTER JOIN@{JOIN_TYPE=APPLY_JOIN} Songs
ON Albums.AlbumId=Songs.AlbumId;
```

```
Query_Execution_Plan (EXPERIMENTAL)

.
└── Distributed Union (subquery_cluster_node: 1)
    └── Serialize Result 
        └── Distributed Outer Apply (subquery_cluster_node: 13)
            ├── [Input]  Create Batch 
            │   └── Distributed Union (call_type: Local, subquery_cluster_node: 5)
            │       └── Compute Struct 
            │           └── Scan (scan_type: IndexScan, scan_target: AlbumsByAlbumTitle, Full scan: true)
            └── [Map]  Cross Apply 
                ├── [Input]  Scan (scan_target: $v2, scan_type: BatchScan)
                └── [Map]  Distributed Union (call_type: Local, subquery_cluster_node: 19)
                    └── FilterScan 
                        └── Scan (scan_type: IndexScan, scan_target: SongsBySingerAlbumSongNameDesc)
```

close #58 