### PR TITLE
Fix broken border when LC_CTYPE is CJK

### DIFF
--- a/query_plan.go
+++ b/query_plan.go
@@ -24,6 +24,13 @@ import (
 	pb "google.golang.org/genproto/googleapis/spanner/v1"
 )
 
+func init() {
+	// Use only ascii characters
+	treeprint.EdgeTypeLink = "|"
+	treeprint.EdgeTypeMid = "+-"
+	treeprint.EdgeTypeEnd = "+-"
+}
+
 type Link struct {
 	Dest *Node
 	Type string


### PR DESCRIPTION
This PR makes `treeprint` not to use ambiguous width characters.

## Example
```
+---------------------------------------------------------------------------------------------------+
| Query_Execution_Plan (EXPERIMENTAL)                                                               |
+---------------------------------------------------------------------------------------------------+
|                                                                                                   |
| .                                                                                                 |
| +- Distributed Union (subquery_cluster_node: 1)                                                   |
|     +- Distributed Cross Apply (subquery_cluster_node: 15)                                        |
|         +- [Input]  Create Batch                                                                  |
|         |   +- Distributed Union (subquery_cluster_node: 4, call_type: Local)                     |
|         |       +- Compute Struct                                                                 |
|         |           +- Scan (scan_target: SongsBySongName, Full scan: true, scan_type: IndexScan) |
|         +- [Map]  Serialize Result                                                                |
|             +- Cross Apply                                                                        |
|                 +- [Input]  Scan (scan_type: BatchScan, scan_target: $v2)                         |
|                 +- [Map]  Distributed Union (call_type: Local, subquery_cluster_node: 23)         |
|                     +- FilterScan                                                                 |
|                         +- Scan (scan_type: TableScan, scan_target: Songs)                        |
|                                                                                                   |
+---------------------------------------------------------------------------------------------------+
```

Considerations:
* `+-` is shorter width than default. `+--` is another choices.
  * Terminal width is limited so shorter is better.

Fixes #61 