### PR TITLE
Combine metadata fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,5 @@ require (
 	google.golang.org/api v0.21.0
 	google.golang.org/genproto v0.0.0-20200416231807-8751e049a2a0
 	google.golang.org/grpc v1.28.1
+	google.golang.org/protobuf v1.21.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.56.0
 	cloud.google.com/go/spanner v1.5.1
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/golang/protobuf v1.4.0
 	github.com/google/go-cmp v0.4.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/mattn/go-runewidth v0.0.8 // indirect
@@ -14,5 +15,4 @@ require (
 	google.golang.org/api v0.21.0
 	google.golang.org/genproto v0.0.0-20200416231807-8751e049a2a0
 	google.golang.org/grpc v1.28.1
-	google.golang.org/protobuf v1.21.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go v0.56.0
 	cloud.google.com/go/spanner v1.5.1
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
-	github.com/golang/protobuf v1.4.0
 	github.com/google/go-cmp v0.4.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/mattn/go-runewidth v0.0.8 // indirect
@@ -15,4 +14,5 @@ require (
 	google.golang.org/api v0.21.0
 	google.golang.org/genproto v0.0.0-20200416231807-8751e049a2a0
 	google.golang.org/grpc v1.28.1
+	google.golang.org/protobuf v1.21.0
 )

--- a/query_plan.go
+++ b/query_plan.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/xlab/treeprint"
@@ -145,6 +146,7 @@ func getAllMetadataString(node *Node) string {
 	if len(fields) == 0 {
 		return ""
 	}
+	sort.Strings(fields)
 	return fmt.Sprintf(`(%s)`, strings.Join(fields, ", "))
 }
 

--- a/query_plan.go
+++ b/query_plan.go
@@ -94,17 +94,6 @@ func (n *Node) String() string {
 	return operator + " " + metadata
 }
 
-func getMetadataString(node *Node, key string) (string, bool) {
-	if node.PlanNode.Metadata == nil {
-		return "", false
-	}
-	if v, ok := node.PlanNode.Metadata.Fields[key]; ok {
-		return v.GetStringValue(), true
-	} else {
-		return "", false
-	}
-}
-
 func getNodeTitle(node *Node) string {
 	fields := node.PlanNode.GetMetadata().GetFields()
 

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"testing"
+
+	"google.golang.org/genproto/googleapis/spanner/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {
+	for _, test := range []struct{
+		node          *Node
+		wantNodeTitle string
+		wantMetadataString string
+	}{
+		{&Node{PlanNode: &spanner.PlanNode{
+			DisplayName: "Distributed Union",
+			Metadata:    &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
+					"subquery_cluster_node": {Kind: &structpb.Value_StringValue{StringValue: "4"}},
+				},
+			},
+		}}, "Local Distributed Union", "",
+		},
+		{&Node{PlanNode: &spanner.PlanNode{
+			DisplayName: "Scan",
+			Metadata:    &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"scan_type": {Kind: &structpb.Value_StringValue{StringValue: "IndexScan"}},
+					"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "SongsBySongName"}},
+					"Full scan": {Kind: &structpb.Value_StringValue{StringValue: "true"}},
+				},
+			},
+		}}, "Index Scan", "(Index: SongsBySongName, Full scan: true)"},
+		{&Node{PlanNode: &spanner.PlanNode{
+			DisplayName: "Scan",
+			Metadata:    &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"scan_type": {Kind: &structpb.Value_StringValue{StringValue: "TableScan"}},
+					"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "Songs"}},
+				},
+			},
+		}}, "Table Scan", "(Table: Songs)"},
+		{&Node{PlanNode: &spanner.PlanNode{
+			DisplayName: "Scan",
+			Metadata:    &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"scan_type": {Kind: &structpb.Value_StringValue{StringValue: "BatchScan"}},
+					"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "$v2"}},
+				},
+			},
+		}}, "Batch Scan", "(Batch: $v2)"},
+		{&Node{PlanNode: &spanner.PlanNode{
+			DisplayName: "Sort Limit",
+			Metadata:    &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
+				},
+			},
+		}}, "Local Sort Limit", ""},
+		{&Node{PlanNode: &spanner.PlanNode{
+			DisplayName: "Sort Limit",
+			Metadata:    &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Global"}},
+				},
+			},
+		}}, "Global Sort Limit", ""},
+		{&Node{PlanNode: &spanner.PlanNode{
+			DisplayName: "Aggregate",
+			Metadata:    &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"iterator_type": {Kind: &structpb.Value_StringValue{StringValue: "Stream"}},
+				},
+			},
+		}}, "Stream Aggregate", ""},
+	} {
+		if got := getNodeTitle(test.node); got != test.wantNodeTitle {
+			t.Errorf("getNodeTitle(%#v) = %q but want %q", test.node, got, test.wantNodeTitle)
+		}
+		if got := getAllMetadataString(test.node); got != test.wantMetadataString {
+			t.Errorf("getAllMetadataString(%#v) = %q but want %q", test.node, got, test.wantMetadataString)
+		}
+	}
+}

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -32,7 +32,7 @@ func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {
 					"Full scan": {Kind: &structpb.Value_StringValue{StringValue: "true"}},
 				},
 			},
-		}}, "Index Scan", "(Index: SongsBySongName, Full scan: true)"},
+		}}, "Index Scan", "(Full scan: true, Index: SongsBySongName)"},
 		{&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Scan",
 			Metadata:    &structpb.Struct{

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -8,16 +8,16 @@ import (
 )
 
 func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {
-	for _, test := range []struct{
-		node          *Node
-		wantNodeTitle string
+	for _, test := range []struct {
+		node               *Node
+		wantNodeTitle      string
 		wantMetadataString string
 	}{
 		{&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Distributed Union",
-			Metadata:    &structpb.Struct{
+			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
+					"call_type":             {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
 					"subquery_cluster_node": {Kind: &structpb.Value_StringValue{StringValue: "4"}},
 				},
 			},
@@ -25,35 +25,35 @@ func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {
 		},
 		{&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Scan",
-			Metadata:    &structpb.Struct{
+			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"scan_type": {Kind: &structpb.Value_StringValue{StringValue: "IndexScan"}},
+					"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "IndexScan"}},
 					"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "SongsBySongName"}},
-					"Full scan": {Kind: &structpb.Value_StringValue{StringValue: "true"}},
+					"Full scan":   {Kind: &structpb.Value_StringValue{StringValue: "true"}},
 				},
 			},
 		}}, "Index Scan", "(Full scan: true, Index: SongsBySongName)"},
 		{&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Scan",
-			Metadata:    &structpb.Struct{
+			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"scan_type": {Kind: &structpb.Value_StringValue{StringValue: "TableScan"}},
+					"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "TableScan"}},
 					"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "Songs"}},
 				},
 			},
 		}}, "Table Scan", "(Table: Songs)"},
 		{&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Scan",
-			Metadata:    &structpb.Struct{
+			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"scan_type": {Kind: &structpb.Value_StringValue{StringValue: "BatchScan"}},
+					"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "BatchScan"}},
 					"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "$v2"}},
 				},
 			},
 		}}, "Batch Scan", "(Batch: $v2)"},
 		{&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Sort Limit",
-			Metadata:    &structpb.Struct{
+			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
 				},
@@ -61,7 +61,7 @@ func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {
 		}}, "Local Sort Limit", ""},
 		{&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Sort Limit",
-			Metadata:    &structpb.Struct{
+			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Global"}},
 				},
@@ -69,7 +69,7 @@ func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {
 		}}, "Global Sort Limit", ""},
 		{&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Aggregate",
-			Metadata:    &structpb.Struct{
+			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"iterator_type": {Kind: &structpb.Value_StringValue{StringValue: "Stream"}},
 				},

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"testing"
 
-	structpb "github.com/golang/protobuf/ptypes/struct"
 	"google.golang.org/genproto/googleapis/spanner/v1"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -7,13 +7,14 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {
+func TestNodeString(t *testing.T) {
 	for _, test := range []struct {
+		title               string
 		node               *Node
-		wantNodeTitle      string
-		wantMetadataString string
+		want string
 	}{
-		{&Node{PlanNode: &spanner.PlanNode{
+		{"Distributed Union with call_type=Local",
+			&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Distributed Union",
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -21,9 +22,10 @@ func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {
 					"subquery_cluster_node": {Kind: &structpb.Value_StringValue{StringValue: "4"}},
 				},
 			},
-		}}, "Local Distributed Union", "",
+		}}, "Local Distributed Union",
 		},
-		{&Node{PlanNode: &spanner.PlanNode{
+		{"Scan with scan_type=IndexScan and Full scan=true",
+			&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Scan",
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -32,8 +34,9 @@ func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {
 					"Full scan":   {Kind: &structpb.Value_StringValue{StringValue: "true"}},
 				},
 			},
-		}}, "Index Scan", "(Full scan: true, Index: SongsBySongName)"},
-		{&Node{PlanNode: &spanner.PlanNode{
+		}}, "Index Scan (Full scan: true, Index: SongsBySongName)"},
+		{ "Scan with scan_type=TableScan",
+			&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Scan",
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -41,8 +44,9 @@ func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {
 					"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "Songs"}},
 				},
 			},
-		}}, "Table Scan", "(Table: Songs)"},
-		{&Node{PlanNode: &spanner.PlanNode{
+		}}, "Table Scan (Table: Songs)"},
+		{"Scan with scan_type=BatchScan",
+			&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Scan",
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -50,37 +54,37 @@ func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {
 					"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "$v2"}},
 				},
 			},
-		}}, "Batch Scan", "(Batch: $v2)"},
-		{&Node{PlanNode: &spanner.PlanNode{
+		}}, "Batch Scan (Batch: $v2)"},
+		{"Sort Limit with call_type=Local",
+			&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Sort Limit",
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
 				},
 			},
-		}}, "Local Sort Limit", ""},
-		{&Node{PlanNode: &spanner.PlanNode{
+		}}, "Local Sort Limit"},
+		{"Sort Limit with call_type=Global",
+			&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Sort Limit",
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Global"}},
 				},
 			},
-		}}, "Global Sort Limit", ""},
-		{&Node{PlanNode: &spanner.PlanNode{
+		}}, "Global Sort Limit"},
+		{"Aggregate with iterator_type=Stream",
+			&Node{PlanNode: &spanner.PlanNode{
 			DisplayName: "Aggregate",
 			Metadata: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"iterator_type": {Kind: &structpb.Value_StringValue{StringValue: "Stream"}},
 				},
 			},
-		}}, "Stream Aggregate", ""},
+		}}, "Stream Aggregate"},
 	} {
-		if got := getNodeTitle(test.node); got != test.wantNodeTitle {
-			t.Errorf("getNodeTitle(%#v) = %q but want %q", test.node, got, test.wantNodeTitle)
-		}
-		if got := getAllMetadataString(test.node); got != test.wantMetadataString {
-			t.Errorf("getAllMetadataString(%#v) = %q but want %q", test.node, got, test.wantMetadataString)
+		if got := test.node.String(); got != test.want {
+			t.Errorf("%s: node.String() = %q but want %q", test.title, got, test.want)
 		}
 	}
 }

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"testing"
 
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"google.golang.org/genproto/googleapis/spanner/v1"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestGetNodeTitleAndGetAllMetadataString(t *testing.T) {


### PR DESCRIPTION
* Combine `scan_type` and `scan_target`
* Combine `call_type`, `iterator_type`, `scan_type` into node title
* Hide `subquery_cluster_node` because `spanner-cli` doesn't display node id

Discussed in https://github.com/cloudspannerecosystem/spanner-cli/issues/57#issuecomment-634399999

## Examples
### Example 1 Distributed Cross Apply(Back Join)

```sql
EXPLAIN SELECT * FROM Songs@{FORCE_INDEX=SongsBySongName}
```

#### Before
```
Query_Execution_Plan (EXPERIMENTAL)

.
+- Distributed Union (subquery_cluster_node: 1)
    +- Distributed Cross Apply (subquery_cluster_node: 15)
        +- [Input]  Create Batch 
        |   +- Distributed Union (subquery_cluster_node: 4, call_type: Local)
        |       +- Compute Struct 
        |           +- Scan (scan_type: IndexScan, scan_target: SongsBySongName, Full scan: true)
        +- [Map]  Serialize Result 
            +- Cross Apply 
                +- [Input]  Scan (scan_type: BatchScan, scan_target: $v2)
                +- [Map]  Distributed Union (call_type: Local, subquery_cluster_node: 23)
                    +- FilterScan 
                        +- Scan (scan_target: Songs, scan_type: TableScan)
```

#### After

```
Query_Execution_Plan (EXPERIMENTAL)

.
+- Distributed Union 
    +- Distributed Cross Apply 
        +- [Input]  Create Batch 
        |   +- Local Distributed Union 
        |       +- Compute Struct 
        |           +- Index Scan (Full scan: true, Index: SongsBySongName)
        +- [Map]  Serialize Result 
            +- Cross Apply 
                +- [Input]  Batch Scan (Batch: $v2)
                +- [Map]  Local Distributed Union 
                    +- FilterScan 
                        +- Table Scan (Table: Songs)
```

### Example 2 Aggregation and Sort Limit

```sql
EXPLAIN SELECT SingerId, COUNT(*) AS SongCount
FROM Songs
GROUP BY SingerId
ORDER BY SongCount DESC
LIMIT 1
```

#### Before

```
Query_Execution_Plan (EXPERIMENTAL)

.
+- Serialize Result 
    +- Sort Limit (call_type: Global)
        +- Distributed Union (subquery_cluster_node: 3)
            +- Sort Limit (call_type: Local)
                +- Aggregate (iterator_type: Stream)
                    +- Distributed Union (subquery_cluster_node: 6, call_type: Local)
                        +- Scan (scan_type: IndexScan, Full scan: true, scan_target: SongsBySingerAlbumSongNameDesc)
```
#### After

```
Query_Execution_Plan (EXPERIMENTAL)

.
+- Serialize Result 
    +- Global Sort Limit 
        +- Distributed Union 
            +- Local Sort Limit 
                +- Stream Aggregate 
                    +- Local Distributed Union 
                        +- Index Scan (Index: SongsBySingerAlbumSongNameDesc, Full scan: true)
```