### PR TITLE
Fix show create table matches prefix of the table name

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -389,7 +389,7 @@ func (s *ShowCreateTableStatement) Execute(session *Session) (*Result, error) {
 		return nil, err
 	}
 	for _, stmt := range ddlResponse.Statements {
-		if regexp.MustCompile(`(?i)^CREATE TABLE ` + s.Table).MatchString(stmt) {
+		if isCreateTableDDL(stmt, s.Table) {
 			resultRow := Row{
 				Columns: []string{s.Table, stmt},
 			}
@@ -404,6 +404,12 @@ func (s *ShowCreateTableStatement) Execute(session *Session) (*Result, error) {
 	result.AffectedRows = len(result.Rows)
 
 	return result, nil
+}
+
+func isCreateTableDDL(ddl string, table string) bool {
+	table = regexp.QuoteMeta(table)
+	re := fmt.Sprintf("(?i)^CREATE TABLE (%s|`%s`)\\s*\\(", table, table)
+	return regexp.MustCompile(re).MatchString(ddl)
 }
 
 type ShowTablesStatement struct{}

--- a/statement_test.go
+++ b/statement_test.go
@@ -287,3 +287,55 @@ func TestBuildStatement(t *testing.T) {
 		}
 	}
 }
+
+func TestIsCreateTableDDL(t *testing.T) {
+	for _, tt := range []struct {
+		desc  string
+		ddl   string
+		table string
+		want  bool
+	}{
+		{
+			desc:  "exact match",
+			ddl:   "CREATE TABLE t1 (\n",
+			table: "t1",
+			want:  true,
+		},
+		{
+			desc:  "given table is prefix of DDL's table",
+			ddl:   "CREATE TABLE t12 (\n",
+			table: "t1",
+			want:  false,
+		},
+		{
+			desc:  "DDL's table is prefix of given table",
+			ddl:   "CREATE TABLE t1 (\n",
+			table: "t12",
+			want:  false,
+		},
+		{
+			desc:  "given table has reserved word",
+			ddl:   "CREATE TABLE `create` (\n",
+			table: "create",
+			want:  true,
+		},
+		{
+			desc:  "given table is regular expression",
+			ddl:   "CREATE TABLE t1 (\n",
+			table: `..`,
+			want:  false,
+		},
+		{
+			desc:  "given table is invalid regular expression",
+			ddl:   "CREATE TABLE t1 (\n",
+			table: `[\]`,
+			want:  false,
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := isCreateTableDDL(tt.ddl, tt.table); got != tt.want {
+				t.Errorf("isCreateTableDDL(%q, %q) = %v, but want %v", tt.ddl, tt.table, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixed `SHOW CREATE TABLE` matches prefix of the table name.

Also fixed spanner-cli panics when user passes the table name which has invalid regular expression.

## Before:
```
spanner> show tables;
+-----------------------------+
| Tables_in_execution_plan_01 |
+-----------------------------+
| Albums                      |
| Concerts                    |
| Singers                     |
| Songs                       |
+-----------------------------+
4 rows in set (0.28 sec)

spanner> show create table Son;
+-------+-------------------------------------------------+
| Table | Create Table                                    |
+-------+-------------------------------------------------+
| Son   | CREATE TABLE Songs (                            |
|       |   SingerId INT64 NOT NULL,                      |
|       |   AlbumId INT64 NOT NULL,                       |
|       |   TrackId INT64 NOT NULL,                       |
|       |   SongName STRING(MAX),                         |
|       |   Duration INT64,                               |
|       |   SongGenre STRING(25),                         |
|       | ) PRIMARY KEY(SingerId, AlbumId, TrackId),      |
|       |   INTERLEAVE IN PARENT Albums ON DELETE CASCADE |
+-------+-------------------------------------------------+
1 rows in set (1.05 sec)
```

## After
```
spanner> show tables;
+-----------------------------+
| Tables_in_execution_plan_01 |
+-----------------------------+
| Albums                      |
| Concerts                    |
| Singers                     |
| Songs                       |
+-----------------------------+
4 rows in set (0.26 sec)

spanner> show create table Son;
ERROR: table "Son" doesn't exist
```