### PR TITLE
Implement EXPLAIN ANALYZE

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The syntax is case-insensitive.
 | DML | `INSERT / UPDATE / DELETE ...;` | |
 | Partitioned DML | | Not supported yet |
 | Show Query Execution Plan | `EXPLAIN SELECT ...;` | |
-| Show Query Execution Plan with Stats(EXPERIMENTAL) | `EXPLAIN ANALYZE SELECT ...;` | |
+| Show Query Execution Plan with Stats | `EXPLAIN ANALYZE SELECT ...;` | EXPERIMENTAL |
 | Start Read-Write Transaction | `BEGIN (RW);` | |
 | Commit Read-Write Transaction | `COMMIT;` | |
 | Rollback Read-Write Transaction | `ROLLBACK;` | |

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The syntax is case-insensitive.
 | DML | `INSERT / UPDATE / DELETE ...;` | |
 | Partitioned DML | | Not supported yet |
 | Show Query Execution Plan | `EXPLAIN SELECT ...;` | |
+| Show Query Execution Plan with Stats(EXPERIMENTAL) | `EXPLAIN ANALYZE SELECT ...;` | |
 | Start Read-Write Transaction | `BEGIN (RW);` | |
 | Commit Read-Write Transaction | `COMMIT;` | |
 | Rollback Read-Write Transaction | `ROLLBACK;` | |

--- a/cli.go
+++ b/cli.go
@@ -370,7 +370,9 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, interactive, v
 		}
 	}
 
-	if interactive {
+	if result.ForceVerbose {
+		fmt.Fprint(out, resultLine(result, true))
+	} else if interactive {
 		fmt.Fprint(out, resultLine(result, verbose))
 	}
 }

--- a/query_plan.go
+++ b/query_plan.go
@@ -235,9 +235,9 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 		&structpb.Value{Kind: &structpb.Value_StructValue{
 			&structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"execution_stats": {Kind: &structpb.Value_StructValue{node.PlanNode.GetExecutionStats()}},
-					"display_name":    {Kind: &structpb.Value_StringValue{node.String()}},
-					"link_type":       {Kind: &structpb.Value_StringValue{linkType}},
+					"execution_stats": {Kind: &structpb.Value_StructValue{StructValue: node.PlanNode.GetExecutionStats()}},
+					"display_name":    {Kind: &structpb.Value_StringValue{StringValue: node.String()}},
+					"link_type":       {Kind: &structpb.Value_StringValue{StringValue: linkType}},
 				},
 			},
 		}},

--- a/query_plan.go
+++ b/query_plan.go
@@ -233,7 +233,7 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 
 	b, _ := protojson.Marshal(
 		&structpb.Value{Kind: &structpb.Value_StructValue{
-			&structpb.Struct{
+			StructValue: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"execution_stats": {Kind: &structpb.Value_StructValue{StructValue: node.PlanNode.GetExecutionStats()}},
 					"display_name":    {Kind: &structpb.Value_StringValue{StringValue: node.String()}},

--- a/query_plan.go
+++ b/query_plan.go
@@ -232,9 +232,9 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 		&structpb.Value{Kind: &structpb.Value_StructValue{
 			&structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"execution_stats": &structpb.Value{Kind: &structpb.Value_StructValue{node.PlanNode.GetExecutionStats()}},
-					"display_name": &structpb.Value{Kind: &structpb.Value_StringValue{node.String()}},
-					"link_type": &structpb.Value{Kind: &structpb.Value_StringValue{linkType}},
+					"execution_stats": {Kind: &structpb.Value_StructValue{node.PlanNode.GetExecutionStats()}},
+					"display_name":    {Kind: &structpb.Value_StringValue{node.String()}},
+					"link_type":       {Kind: &structpb.Value_StringValue{linkType}},
 				},
 			},
 		}},
@@ -242,8 +242,7 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 	str := string(b)
 
 	if len(node.Children) > 0 {
-		var branch treeprint.Tree
-		branch = tree.AddBranch(str)
+		branch := tree.AddBranch(str)
 		for _, child := range node.Children {
 			renderTreeWithStats(branch, child.Type, child.Dest)
 		}

--- a/query_plan.go
+++ b/query_plan.go
@@ -232,15 +232,13 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 	}
 
 	b, _ := protojson.Marshal(
-		&structpb.Value{Kind: &structpb.Value_StructValue{
-			StructValue: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"execution_stats": {Kind: &structpb.Value_StructValue{StructValue: node.PlanNode.GetExecutionStats()}},
-					"display_name":    {Kind: &structpb.Value_StringValue{StringValue: node.String()}},
-					"link_type":       {Kind: &structpb.Value_StringValue{StringValue: linkType}},
-				},
+		&structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"execution_stats": {Kind: &structpb.Value_StructValue{StructValue: node.PlanNode.GetExecutionStats()}},
+				"display_name":    {Kind: &structpb.Value_StringValue{StringValue: node.String()}},
+				"link_type":       {Kind: &structpb.Value_StringValue{StringValue: linkType}},
 			},
-		}},
+		},
 	)
 	str := string(b)
 

--- a/query_plan.go
+++ b/query_plan.go
@@ -80,9 +80,9 @@ func (n *Node) Render() string {
 }
 
 type RenderedTreeWithStats struct {
-	Text string
-	RowsTotal string
-	Execution string
+	Text         string
+	RowsTotal    string
+	Execution    string
 	LatencyTotal string
 }
 
@@ -139,7 +139,6 @@ func (n *Node) String() string {
 		}
 		operator = strings.Join(components, " ")
 	}
-
 
 	var metadata string
 	{
@@ -209,7 +208,7 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 		node.PlanNode.GetExecutionStats().GetFields()["rows"].GetStructValue().GetFields()["total"].GetStringValue(),
 		node.PlanNode.GetExecutionStats().GetFields()["execution_summary"].GetStructValue().GetFields()["num_executions"].GetStringValue(),
 		node.PlanNode.GetExecutionStats().GetFields()["latency"].GetStructValue().GetFields()["total"].GetStringValue(),
-		)
+	)
 
 	if len(node.Children) > 0 {
 		var branch treeprint.Tree

--- a/query_plan.go
+++ b/query_plan.go
@@ -96,12 +96,13 @@ func (n *Node) RenderTreeWithStats() []RenderedTreeWithStats {
 		if line == "" {
 			continue
 		}
-		i := strings.Index(line, "{")
-		if i == -1 {
+
+		idx := strings.Index(line, "{")
+		if idx == -1 {
 			result = append(result, RenderedTreeWithStats{Text: line})
 			continue
 		}
-		branchText, protojsonText := line[:i], line[i:]
+		branchText, protojsonText := line[:idx], line[idx:]
 
 		var value structpb.Value
 		err := protojson.Unmarshal([]byte(protojsonText), &value)

--- a/query_plan.go
+++ b/query_plan.go
@@ -91,24 +91,21 @@ func (n *Node) RenderTreeWithStats() []RenderedTreeWithStats {
 	tree := treeprint.New()
 	renderTreeWithStats(tree, "", n)
 	var result []RenderedTreeWithStats
-	renderedTree := tree.String()
-	for _, line := range strings.Split(renderedTree, "\n") {
+	for _, line := range strings.Split(tree.String(), "\n") {
 		if line == "" {
 			continue
 		}
 		tsv := strings.Split(line, "\t")
-		elem := RenderedTreeWithStats{}
-		elem.Text = tsv[0]
-		if len(tsv) > 1 {
-			elem.RowsTotal = tsv[1]
+		if len(tsv) == 1 {
+			result = append(result, RenderedTreeWithStats{Text: tsv[0]})
+			continue
 		}
-		if len(tsv) > 2 {
-			elem.Execution = tsv[2]
-		}
-		if len(tsv) > 3 {
-			elem.LatencyTotal = tsv[3]
-		}
-		result = append(result, elem)
+		result = append(result, RenderedTreeWithStats{
+			Text:         tsv[0],
+			RowsTotal:    tsv[1],
+			Execution:    tsv[2],
+			LatencyTotal: tsv[3],
+		})
 	}
 	return result
 }

--- a/query_plan.go
+++ b/query_plan.go
@@ -107,8 +107,7 @@ func (n *Node) RenderTreeWithStats() []RenderedTreeWithStats {
 		branchText, protojsonText := split[0], split[1]
 
 		var value structpb.Value
-		err := protojson.Unmarshal([]byte(protojsonText), &value)
-		if err != nil {
+		if err := protojson.Unmarshal([]byte(protojsonText), &value); err != nil {
 			result = append(result, RenderedTreeWithStats{Text: line})
 			continue
 		}

--- a/query_plan.go
+++ b/query_plan.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -231,13 +232,12 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 		return
 	}
 
-	b, _ := protojson.Marshal(
-		&structpb.Struct{
-			Fields: map[string]*structpb.Value{
-				"execution_stats": {Kind: &structpb.Value_StructValue{StructValue: node.PlanNode.GetExecutionStats()}},
-				"display_name":    {Kind: &structpb.Value_StringValue{StringValue: node.String()}},
-				"link_type":       {Kind: &structpb.Value_StringValue{StringValue: linkType}},
-			},
+	statsJson, _ := protojson.Marshal(node.PlanNode.GetExecutionStats())
+	b, _ := json.Marshal(
+		map[string]interface{}{
+				"execution_stats": json.RawMessage(statsJson),
+				"display_name":    node.String(),
+				"link_type":       linkType,
 		},
 	)
 	str := string(b)

--- a/query_plan.go
+++ b/query_plan.go
@@ -98,12 +98,12 @@ func (n *Node) RenderTreeWithStats() []RenderedTreeWithStats {
 			continue
 		}
 
-		idx := strings.Index(line, "{")
-		if idx == -1 {
+		split := strings.Split(line, "\t")
+		if len(split) == 1 {
 			result = append(result, RenderedTreeWithStats{Text: line})
 			continue
 		}
-		branchText, protojsonText := line[:idx], line[idx:]
+		branchText, protojsonText := split[0], split[1]
 
 		var value structpb.Value
 		err := protojson.Unmarshal([]byte(protojsonText), &value)
@@ -240,7 +240,7 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 				"link_type":       linkType,
 		},
 	)
-	str := string(b)
+	str := "\t" + string(b)
 
 	if len(node.Children) > 0 {
 		branch := tree.AddBranch(str)

--- a/query_plan.go
+++ b/query_plan.go
@@ -99,8 +99,8 @@ func (n *Node) RenderTreeWithStats() []RenderedTreeWithStats {
 		}
 
 		split := strings.SplitN(line, "\t", 2)
-		// The root node of treeprint
-		if len(split) == 1 {
+		// Handle the case of the root node of treeprint
+		if len(split) != 2 {
 			result = append(result, RenderedTreeWithStats{Text: line})
 			continue
 		}

--- a/query_plan.go
+++ b/query_plan.go
@@ -126,7 +126,7 @@ func (n *Node) RenderTreeWithStats() []RenderedTreeWithStats {
 			Text:         branchText + text,
 			RowsTotal:    getStringValueByPath(value.GetStructValue(), "execution_stats", "rows", "total"),
 			Execution:    getStringValueByPath(value.GetStructValue(), "execution_stats", "execution_summary", "num_executions"),
-			LatencyTotal: getStringValueByPath(value.GetStructValue(), "execution_stats", "latency", "total"),
+			LatencyTotal: getStringValueByPath(value.GetStructValue(), "execution_stats", "latency", "total") + " " + getStringValueByPath(value.GetStructValue(), "execution_stats", "latency", "unit"),
 		})
 	}
 	return result

--- a/query_plan.go
+++ b/query_plan.go
@@ -98,7 +98,8 @@ func (n *Node) RenderTreeWithStats() []RenderedTreeWithStats {
 			continue
 		}
 
-		split := strings.Split(line, "\t")
+		split := strings.SplitN(line, "\t", 2)
+		// The root node of treeprint
 		if len(split) == 1 {
 			result = append(result, RenderedTreeWithStats{Text: line})
 			continue

--- a/query_plan.go
+++ b/query_plan.go
@@ -101,8 +101,9 @@ func (n *Node) RenderTreeWithStats() []RenderedTreeWithStats {
 			result = append(result, RenderedTreeWithStats{Text: line})
 			continue
 		}
-		var value structpb.Value
 		branchText, protojsonText := line[:i], line[i:]
+
+		var value structpb.Value
 		err := protojson.Unmarshal([]byte(protojsonText), &value)
 		if err != nil {
 			result = append(result, RenderedTreeWithStats{Text: line})
@@ -118,6 +119,7 @@ func (n *Node) RenderTreeWithStats() []RenderedTreeWithStats {
 		} else {
 			text = displayName
 		}
+
 		result = append(result, RenderedTreeWithStats{
 			Text:         branchText + text,
 			RowsTotal:    getStringValueByPath(value.GetStructValue(), "execution_stats", "rows", "total"),

--- a/query_plan.go
+++ b/query_plan.go
@@ -123,10 +123,12 @@ func (n *Node) RenderTreeWithStats() []RenderedTreeWithStats {
 		}
 
 		result = append(result, RenderedTreeWithStats{
-			Text:         branchText + text,
-			RowsTotal:    getStringValueByPath(value.GetStructValue(), "execution_stats", "rows", "total"),
-			Execution:    getStringValueByPath(value.GetStructValue(), "execution_stats", "execution_summary", "num_executions"),
-			LatencyTotal: getStringValueByPath(value.GetStructValue(), "execution_stats", "latency", "total") + " " + getStringValueByPath(value.GetStructValue(), "execution_stats", "latency", "unit"),
+			Text:      branchText + text,
+			RowsTotal: getStringValueByPath(value.GetStructValue(), "execution_stats", "rows", "total"),
+			Execution: getStringValueByPath(value.GetStructValue(), "execution_stats", "execution_summary", "num_executions"),
+			LatencyTotal: fmt.Sprintf("%s %s",
+				getStringValueByPath(value.GetStructValue(), "execution_stats", "latency", "total"),
+				getStringValueByPath(value.GetStructValue(), "execution_stats", "latency", "unit")),
 		})
 	}
 	return result
@@ -235,11 +237,12 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 	statsJson, _ := protojson.Marshal(node.PlanNode.GetExecutionStats())
 	b, _ := json.Marshal(
 		map[string]interface{}{
-				"execution_stats": json.RawMessage(statsJson),
-				"display_name":    node.String(),
-				"link_type":       linkType,
+			"execution_stats": json.RawMessage(statsJson),
+			"display_name":    node.String(),
+			"link_type":       linkType,
 		},
 	)
+	// Prefixed by tab to ease to split
 	str := "\t" + string(b)
 
 	if len(node.Children) > 0 {

--- a/query_plan.go
+++ b/query_plan.go
@@ -197,7 +197,7 @@ func renderTree(tree treeprint.Tree, linkType string, node *Node) {
 	}
 }
 
-func getStringValueFromPath(s *structpb.Struct, first string, path ...string) string {
+func getStringValueByPath(s *structpb.Struct, first string, path ...string) string {
 	current := s.GetFields()[first]
 	for _, p := range path {
 		current = current.GetStructValue().GetFields()[p]
@@ -212,9 +212,9 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 
 	executionStats := node.PlanNode.GetExecutionStats()
 	str := fmt.Sprintf("%s\t%s\t%s\t%s", node.String(),
-		getStringValueFromPath(executionStats, "rows", "total"),
-		getStringValueFromPath(executionStats, "execution_summary", "num_executions"),
-		getStringValueFromPath(executionStats, "latency", "total"),
+		getStringValueByPath(executionStats, "rows", "total"),
+		getStringValueByPath(executionStats, "execution_summary", "num_executions"),
+		getStringValueByPath(executionStats, "latency", "total"),
 	)
 
 	if len(node.Children) > 0 {

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -33,20 +33,12 @@ func TestRenderTreeWithStats(t *testing.T) {
 						},
 						DisplayName: "Distributed Union",
 						Kind:        spanner.PlanNode_RELATIONAL,
-						ExecutionStats: &structpb.Struct{Fields: map[string]*structpb.Value{
-							"latency": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"total": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
-									"unit":  {Kind: &structpb.Value_StringValue{StringValue: "msec"}},
-								}}}},
-							"execution_summary": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"num_executions": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
-								}}}},
-							"rows": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"total": {Kind: &structpb.Value_StringValue{StringValue: "9"}},
-								}}}}}},
+						ExecutionStats: protojsonAsStruct(`
+{
+  "latency": {"total": "1", "unit": "msec"},
+  "rows": {"total": "9"},
+  "execution_summary": {"num_executions": "1"},
+}`),
 					},
 					{
 						ChildLinks: []*spanner.PlanNode_ChildLink{
@@ -57,20 +49,12 @@ func TestRenderTreeWithStats(t *testing.T) {
 						DisplayName: "Distributed Union",
 						Kind:        spanner.PlanNode_RELATIONAL,
 						Metadata:    protojsonAsStruct(`{"call_type": "Local"}`),
-						ExecutionStats: &structpb.Struct{Fields: map[string]*structpb.Value{
-							"latency": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"total": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
-									"unit":  {Kind: &structpb.Value_StringValue{StringValue: "msec"}},
-								}}}},
-							"execution_summary": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"num_executions": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
-								}}}},
-							"rows": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"total": {Kind: &structpb.Value_StringValue{StringValue: "9"}},
-								}}}}}},
+						ExecutionStats: protojsonAsStruct(`
+{
+  "latency": {"total": "1", "unit": "msec"},
+  "rows": {"total": "9"},
+  "execution_summary": {"num_executions": "1"},
+}`),
 					},
 					{
 						ChildLinks: []*spanner.PlanNode_ChildLink{
@@ -80,39 +64,23 @@ func TestRenderTreeWithStats(t *testing.T) {
 						},
 						DisplayName: "Serialize Result",
 						Kind:        spanner.PlanNode_RELATIONAL,
-						ExecutionStats: &structpb.Struct{Fields: map[string]*structpb.Value{
-							"latency": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"total": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
-									"unit":  {Kind: &structpb.Value_StringValue{StringValue: "msec"}},
-								}}}},
-							"execution_summary": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"num_executions": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
-								}}}},
-							"rows": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"total": {Kind: &structpb.Value_StringValue{StringValue: "9"}},
-								}}}}}},
+						ExecutionStats: protojsonAsStruct(`
+{
+  "latency": {"total": "1", "unit": "msec"},
+  "rows": {"total": "9"},
+  "execution_summary": {"num_executions": "1"},
+}`),
 					},
 					{
 						DisplayName: "Scan",
 						Kind:        spanner.PlanNode_RELATIONAL,
 						Metadata:    protojsonAsStruct(`{"scan_type": "IndexScan", "scan_target": "SongsBySingerAlbumSongNameDesc", "Full scan": "true"}`),
-						ExecutionStats: &structpb.Struct{Fields: map[string]*structpb.Value{
-							"latency": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"total": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
-									"unit":  {Kind: &structpb.Value_StringValue{StringValue: "msec"}},
-								}}}},
-							"execution_summary": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"num_executions": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
-								}}}},
-							"rows": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
-								Fields: map[string]*structpb.Value{
-									"total": {Kind: &structpb.Value_StringValue{StringValue: "9"}},
-								}}}}}},
+						ExecutionStats: protojsonAsStruct(`
+{
+  "latency": {"total": "1", "unit": "msec"},
+  "rows": {"total": "9"},
+  "execution_summary": {"num_executions": "1"},
+}`),
 					},
 				},
 			},

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -3,10 +3,153 @@ package main
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genproto/googleapis/spanner/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+func protojsonAsStruct(j string) *structpb.Struct {
+	var result structpb.Struct
+	if err := protojson.Unmarshal([]byte(j), &result); err != nil {
+		return nil
+	}
+	return &result
+}
+func TestRenderTreeWithStats(t *testing.T) {
+	for _, test := range []struct {
+		title string
+		plan  *spanner.QueryPlan
+		want  []RenderedTreeWithStats
+	}{
+		{title: "Simple Query",
+			plan: &spanner.QueryPlan{
+				PlanNodes: []*spanner.PlanNode{
+					{
+						ChildLinks: []*spanner.PlanNode_ChildLink{
+							{
+								ChildIndex: 1,
+							},
+						},
+						DisplayName: "Distributed Union",
+						Kind:        spanner.PlanNode_RELATIONAL,
+						ExecutionStats: &structpb.Struct{Fields: map[string]*structpb.Value{
+							"latency": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"total": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
+									"unit":  {Kind: &structpb.Value_StringValue{StringValue: "msec"}},
+								}}}},
+							"execution_summary": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"num_executions": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
+								}}}},
+							"rows": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"total": {Kind: &structpb.Value_StringValue{StringValue: "9"}},
+								}}}}}},
+					},
+					{
+						ChildLinks: []*spanner.PlanNode_ChildLink{
+							{
+								ChildIndex: 2,
+							},
+						},
+						DisplayName: "Distributed Union",
+						Kind:        spanner.PlanNode_RELATIONAL,
+						Metadata:    protojsonAsStruct(`{"call_type": "Local"}`),
+						ExecutionStats: &structpb.Struct{Fields: map[string]*structpb.Value{
+							"latency": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"total": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
+									"unit":  {Kind: &structpb.Value_StringValue{StringValue: "msec"}},
+								}}}},
+							"execution_summary": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"num_executions": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
+								}}}},
+							"rows": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"total": {Kind: &structpb.Value_StringValue{StringValue: "9"}},
+								}}}}}},
+					},
+					{
+						ChildLinks: []*spanner.PlanNode_ChildLink{
+							{
+								ChildIndex: 3,
+							},
+						},
+						DisplayName: "Serialize Result",
+						Kind:        spanner.PlanNode_RELATIONAL,
+						ExecutionStats: &structpb.Struct{Fields: map[string]*structpb.Value{
+							"latency": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"total": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
+									"unit":  {Kind: &structpb.Value_StringValue{StringValue: "msec"}},
+								}}}},
+							"execution_summary": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"num_executions": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
+								}}}},
+							"rows": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"total": {Kind: &structpb.Value_StringValue{StringValue: "9"}},
+								}}}}}},
+					},
+					{
+						DisplayName: "Scan",
+						Kind:        spanner.PlanNode_RELATIONAL,
+						Metadata:    protojsonAsStruct(`{"scan_type": "IndexScan", "scan_target": "SongsBySingerAlbumSongNameDesc", "Full scan": "true"}`),
+						ExecutionStats: &structpb.Struct{Fields: map[string]*structpb.Value{
+							"latency": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"total": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
+									"unit":  {Kind: &structpb.Value_StringValue{StringValue: "msec"}},
+								}}}},
+							"execution_summary": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"num_executions": {Kind: &structpb.Value_StringValue{StringValue: "1"}},
+								}}}},
+							"rows": &structpb.Value{Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"total": {Kind: &structpb.Value_StringValue{StringValue: "9"}},
+								}}}}}},
+					},
+				},
+			},
+			want: []RenderedTreeWithStats{
+				{Text: "."},
+				{
+					Text:         "+- Distributed Union",
+					RowsTotal:    "9",
+					Execution:    "1",
+					LatencyTotal: "1 msec",
+				},
+				{
+					Text:         "    +- Local Distributed Union",
+					RowsTotal:    "9",
+					Execution:    "1",
+					LatencyTotal: "1 msec",
+				},
+				{
+					Text:         "        +- Serialize Result",
+					RowsTotal:    "9",
+					Execution:    "1",
+					LatencyTotal: "1 msec",
+				},
+				{
+					Text:         "            +- Index Scan (Full scan: true, Index: SongsBySingerAlbumSongNameDesc)",
+					RowsTotal:    "9",
+					Execution:    "1",
+					LatencyTotal: "1 msec",
+				},
+			}},
+	} {
+		tree := BuildQueryPlanTree(test.plan, 0)
+		if got := tree.RenderTreeWithStats(); !cmp.Equal(test.want, got) {
+			t.Errorf("%s: node.RenderTreeWithStats() differ: %s", test.title, cmp.Diff(test.want, got))
+		}
+	}
+}
 func TestNodeString(t *testing.T) {
 	for _, test := range []struct {
 		title string

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -9,79 +9,79 @@ import (
 
 func TestNodeString(t *testing.T) {
 	for _, test := range []struct {
-		title               string
-		node               *Node
-		want string
+		title string
+		node  *Node
+		want  string
 	}{
 		{"Distributed Union with call_type=Local",
 			&Node{PlanNode: &spanner.PlanNode{
-			DisplayName: "Distributed Union",
-			Metadata: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"call_type":             {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
-					"subquery_cluster_node": {Kind: &structpb.Value_StringValue{StringValue: "4"}},
+				DisplayName: "Distributed Union",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"call_type":             {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
+						"subquery_cluster_node": {Kind: &structpb.Value_StringValue{StringValue: "4"}},
+					},
 				},
-			},
-		}}, "Local Distributed Union",
+			}}, "Local Distributed Union",
 		},
 		{"Scan with scan_type=IndexScan and Full scan=true",
 			&Node{PlanNode: &spanner.PlanNode{
-			DisplayName: "Scan",
-			Metadata: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "IndexScan"}},
-					"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "SongsBySongName"}},
-					"Full scan":   {Kind: &structpb.Value_StringValue{StringValue: "true"}},
+				DisplayName: "Scan",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "IndexScan"}},
+						"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "SongsBySongName"}},
+						"Full scan":   {Kind: &structpb.Value_StringValue{StringValue: "true"}},
+					},
 				},
-			},
-		}}, "Index Scan (Full scan: true, Index: SongsBySongName)"},
-		{ "Scan with scan_type=TableScan",
+			}}, "Index Scan (Full scan: true, Index: SongsBySongName)"},
+		{"Scan with scan_type=TableScan",
 			&Node{PlanNode: &spanner.PlanNode{
-			DisplayName: "Scan",
-			Metadata: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "TableScan"}},
-					"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "Songs"}},
+				DisplayName: "Scan",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "TableScan"}},
+						"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "Songs"}},
+					},
 				},
-			},
-		}}, "Table Scan (Table: Songs)"},
+			}}, "Table Scan (Table: Songs)"},
 		{"Scan with scan_type=BatchScan",
 			&Node{PlanNode: &spanner.PlanNode{
-			DisplayName: "Scan",
-			Metadata: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "BatchScan"}},
-					"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "$v2"}},
+				DisplayName: "Scan",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "BatchScan"}},
+						"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "$v2"}},
+					},
 				},
-			},
-		}}, "Batch Scan (Batch: $v2)"},
+			}}, "Batch Scan (Batch: $v2)"},
 		{"Sort Limit with call_type=Local",
 			&Node{PlanNode: &spanner.PlanNode{
-			DisplayName: "Sort Limit",
-			Metadata: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
+				DisplayName: "Sort Limit",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
+					},
 				},
-			},
-		}}, "Local Sort Limit"},
+			}}, "Local Sort Limit"},
 		{"Sort Limit with call_type=Global",
 			&Node{PlanNode: &spanner.PlanNode{
-			DisplayName: "Sort Limit",
-			Metadata: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Global"}},
+				DisplayName: "Sort Limit",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Global"}},
+					},
 				},
-			},
-		}}, "Global Sort Limit"},
+			}}, "Global Sort Limit"},
 		{"Aggregate with iterator_type=Stream",
 			&Node{PlanNode: &spanner.PlanNode{
-			DisplayName: "Aggregate",
-			Metadata: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"iterator_type": {Kind: &structpb.Value_StringValue{StringValue: "Stream"}},
+				DisplayName: "Aggregate",
+				Metadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"iterator_type": {Kind: &structpb.Value_StringValue{StringValue: "Stream"}},
+					},
 				},
-			},
-		}}, "Stream Aggregate"},
+			}}, "Stream Aggregate"},
 	} {
 		if got := test.node.String(); got != test.want {
 			t.Errorf("%s: node.String() = %q but want %q", test.title, got, test.want)

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -9,13 +9,15 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func protojsonAsStruct(j string) *structpb.Struct {
+func protojsonAsStruct(t *testing.T, j string) *structpb.Struct {
+	t.Helper()
 	var result structpb.Struct
 	if err := protojson.Unmarshal([]byte(j), &result); err != nil {
-		return nil
+		t.Fatal("protojsonAsStruct fails, invalid test case", err)
 	}
 	return &result
 }
+
 func TestRenderTreeWithStats(t *testing.T) {
 	for _, test := range []struct {
 		title string
@@ -33,11 +35,11 @@ func TestRenderTreeWithStats(t *testing.T) {
 						},
 						DisplayName: "Distributed Union",
 						Kind:        spanner.PlanNode_RELATIONAL,
-						ExecutionStats: protojsonAsStruct(`
+						ExecutionStats: protojsonAsStruct(t, `
 {
   "latency": {"total": "1", "unit": "msec"},
   "rows": {"total": "9"},
-  "execution_summary": {"num_executions": "1"},
+  "execution_summary": {"num_executions": "1"}
 }`),
 					},
 					{
@@ -48,12 +50,12 @@ func TestRenderTreeWithStats(t *testing.T) {
 						},
 						DisplayName: "Distributed Union",
 						Kind:        spanner.PlanNode_RELATIONAL,
-						Metadata:    protojsonAsStruct(`{"call_type": "Local"}`),
-						ExecutionStats: protojsonAsStruct(`
+						Metadata:    protojsonAsStruct(t, `{"call_type": "Local"}`),
+						ExecutionStats: protojsonAsStruct(t, `
 {
   "latency": {"total": "1", "unit": "msec"},
   "rows": {"total": "9"},
-  "execution_summary": {"num_executions": "1"},
+  "execution_summary": {"num_executions": "1"}
 }`),
 					},
 					{
@@ -64,22 +66,22 @@ func TestRenderTreeWithStats(t *testing.T) {
 						},
 						DisplayName: "Serialize Result",
 						Kind:        spanner.PlanNode_RELATIONAL,
-						ExecutionStats: protojsonAsStruct(`
+						ExecutionStats: protojsonAsStruct(t, `
 {
   "latency": {"total": "1", "unit": "msec"},
   "rows": {"total": "9"},
-  "execution_summary": {"num_executions": "1"},
+  "execution_summary": {"num_executions": "1"}
 }`),
 					},
 					{
 						DisplayName: "Scan",
 						Kind:        spanner.PlanNode_RELATIONAL,
-						Metadata:    protojsonAsStruct(`{"scan_type": "IndexScan", "scan_target": "SongsBySingerAlbumSongNameDesc", "Full scan": "true"}`),
-						ExecutionStats: protojsonAsStruct(`
+						Metadata:    protojsonAsStruct(t, `{"scan_type": "IndexScan", "scan_target": "SongsBySingerAlbumSongNameDesc", "Full scan": "true"}`),
+						ExecutionStats: protojsonAsStruct(t, `
 {
   "latency": {"total": "1", "unit": "msec"},
   "rows": {"total": "9"},
-  "execution_summary": {"num_executions": "1"},
+  "execution_summary": {"num_executions": "1"}
 }`),
 					},
 				},

--- a/statement.go
+++ b/statement.go
@@ -496,7 +496,7 @@ func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
 	}
 
 	result := &Result{
-		ColumnNames: []string{"Query_Execution_Plan", "Rows", "Exec.", "Latency"},
+		ColumnNames:  []string{"Query_Execution_Plan", "Rows", "Exec.", "Latency"},
 		ForceVerbose: true,
 	}
 

--- a/statement.go
+++ b/statement.go
@@ -496,7 +496,7 @@ func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
 	}
 
 	result := &Result{
-		ColumnNames:  []string{"Query_Execution_Plan", "Rows", "Exec.", "Latency"},
+		ColumnNames:  []string{"Query_Execution_Plan", "Rows_Returned", "Executions", "Total_Latency"},
 		ForceVerbose: true,
 	}
 

--- a/statement.go
+++ b/statement.go
@@ -137,7 +137,7 @@ func BuildStatement(input string) (Statement, error) {
 		return &ExplainStatement{Explain: matched[1]}, nil
 	case explainAnalyzeRe.MatchString(input):
 		matched := explainAnalyzeRe.FindStringSubmatch(input)
-		return &ExplainAnalyzeStatement{Explain: matched[1]}, nil
+		return &ExplainAnalyzeStatement{Query: matched[1]}, nil
 	case showColumnsRe.MatchString(input):
 		matched := showColumnsRe.FindStringSubmatch(input)
 		return &ShowColumnsStatement{Table: unquoteIdentifier(matched[1])}, nil
@@ -469,11 +469,11 @@ func (s *ExplainStatement) Execute(session *Session) (*Result, error) {
 }
 
 type ExplainAnalyzeStatement struct {
-	Explain string
+	Query string
 }
 
 func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
-	stmt := spanner.NewStatement(s.Explain)
+	stmt := spanner.NewStatement(s.Query)
 	var iter *spanner.RowIterator
 
 	var targetRoTxn *spanner.ReadOnlyTransaction

--- a/statement.go
+++ b/statement.go
@@ -92,6 +92,7 @@ var (
 	showColumnsRe     = regexp.MustCompile(`(?is)^(?:SHOW\s+COLUMNS\s+FROM)\s+(.+)$`)
 	showIndexRe       = regexp.MustCompile(`(?is)^SHOW\s+(?:INDEX|INDEXES|KEYS)\s+FROM\s+(.+)$`)
 	explainRe         = regexp.MustCompile(`(?is)^(?:EXPLAIN|DESC(?:RIBE)?)\s+((?:WITH|@{.+|SELECT)\s+.+)$`)
+	explainAnalyzeRe         = regexp.MustCompile(`(?is)^(?:EXPLAIN|DESC(?:RIBE)?)\s+ANALYZE\s+(.+)$`)
 )
 
 var (
@@ -133,6 +134,9 @@ func BuildStatement(input string) (Statement, error) {
 	case explainRe.MatchString(input):
 		matched := explainRe.FindStringSubmatch(input)
 		return &ExplainStatement{Explain: matched[1]}, nil
+	case explainAnalyzeRe.MatchString(input):
+		matched := explainAnalyzeRe.FindStringSubmatch(input)
+		return &ExplainAnalyzeStatement{Explain: matched[1]}, nil
 	case showColumnsRe.MatchString(input):
 		matched := showColumnsRe.FindStringSubmatch(input)
 		return &ShowColumnsStatement{Table: unquoteIdentifier(matched[1])}, nil
@@ -459,6 +463,59 @@ func (s *ExplainStatement) Execute(session *Session) (*Result, error) {
 	tree := BuildQueryPlanTree(queryPlan, 0)
 	rendered := tree.Render()
 	result.Rows[0] = Row{[]string{rendered}}
+
+	return result, nil
+}
+
+type ExplainAnalyzeStatement struct {
+	Explain string
+}
+
+func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
+	stmt := spanner.NewStatement(s.Explain)
+	var iter *spanner.RowIterator
+
+	var targetRoTxn *spanner.ReadOnlyTransaction
+	if session.InRwTxn() {
+		iter = session.rwTxn.QueryWithStats(session.ctx, stmt)
+	} else if session.InRoTxn() {
+		targetRoTxn = session.roTxn
+		iter = targetRoTxn.QueryWithStats(session.ctx, stmt)
+	} else {
+		targetRoTxn = session.client.Single()
+		iter = targetRoTxn.QueryWithStats(session.ctx, stmt)
+	}
+	defer iter.Stop()
+	// consume iter
+	err := iter.Do(func(*spanner.Row) error {
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &Result{
+		ColumnNames:  []string{"Query_Execution_Plan", "Rows", "Exec.", "Latency"},
+	}
+
+	tree := BuildQueryPlanTree(iter.QueryPlan, 0)
+	queryStats := parseQueryStats(iter.QueryStats)
+	rowsReturned, err := strconv.Atoi(queryStats.RowsReturned)
+	if err != nil {
+		return nil, fmt.Errorf("rowsReturned is invalid: %v", err)
+	}
+
+	result.AffectedRows = rowsReturned
+	result.Stats = queryStats
+
+	// ReadOnlyTransaction.Timestamp() is invalid until read.
+	if targetRoTxn != nil {
+		result.Timestamp, _ = targetRoTxn.Timestamp()
+	}
+
+	for _, row := range tree.RenderTreeWithStats() {
+		result.Rows = append(result.Rows, Row{[]string{row.Text, row.RowsTotal, row.Execution, row.LatencyTotal}})
+	}
 
 	return result, nil
 }

--- a/statement.go
+++ b/statement.go
@@ -41,6 +41,7 @@ type Result struct {
 	Stats        QueryStats
 	IsMutation   bool
 	Timestamp    time.Time
+	ForceVerbose bool
 }
 
 type Row struct {
@@ -496,6 +497,7 @@ func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
 
 	result := &Result{
 		ColumnNames: []string{"Query_Execution_Plan", "Rows", "Exec.", "Latency"},
+		ForceVerbose: true,
 	}
 
 	tree := BuildQueryPlanTree(iter.QueryPlan, 0)
@@ -513,8 +515,7 @@ func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
 		result.Timestamp, _ = targetRoTxn.Timestamp()
 	}
 
-	renderedTree := tree.RenderTreeWithStats()
-	for _, row := range renderedTree {
+	for _, row := range tree.RenderTreeWithStats() {
 		result.Rows = append(result.Rows, Row{[]string{row.Text, row.RowsTotal, row.Execution, row.LatencyTotal}})
 	}
 

--- a/statement.go
+++ b/statement.go
@@ -92,7 +92,7 @@ var (
 	showColumnsRe     = regexp.MustCompile(`(?is)^(?:SHOW\s+COLUMNS\s+FROM)\s+(.+)$`)
 	showIndexRe       = regexp.MustCompile(`(?is)^SHOW\s+(?:INDEX|INDEXES|KEYS)\s+FROM\s+(.+)$`)
 	explainRe         = regexp.MustCompile(`(?is)^(?:EXPLAIN|DESC(?:RIBE)?)\s+((?:WITH|@{.+|SELECT)\s+.+)$`)
-	explainAnalyzeRe         = regexp.MustCompile(`(?is)^(?:EXPLAIN|DESC(?:RIBE)?)\s+ANALYZE\s+(.+)$`)
+	explainAnalyzeRe  = regexp.MustCompile(`(?is)^EXPLAIN\s+ANALYZE\s+(.+)$`)
 )
 
 var (
@@ -495,7 +495,7 @@ func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
 	}
 
 	result := &Result{
-		ColumnNames:  []string{"Query_Execution_Plan", "Rows", "Exec.", "Latency"},
+		ColumnNames: []string{"Query_Execution_Plan", "Rows", "Exec.", "Latency"},
 	}
 
 	tree := BuildQueryPlanTree(iter.QueryPlan, 0)

--- a/statement.go
+++ b/statement.go
@@ -513,7 +513,8 @@ func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
 		result.Timestamp, _ = targetRoTxn.Timestamp()
 	}
 
-	for _, row := range tree.RenderTreeWithStats() {
+	renderedTree := tree.RenderTreeWithStats()
+	for _, row := range renderedTree {
 		result.Rows = append(result.Rows, Row{[]string{row.Text, row.RowsTotal, row.Execution, row.LatencyTotal}})
 	}
 


### PR DESCRIPTION
* [x] Implement `EXPLAIN ANALYZE` statement
* [x] Render tree with stats in table
  * [x] Add unit of latency
* [x] Always print verbose result line when `EXPLAIN ANALYZE`
* [x] Add simple test

Considerations:
* How to pair rendered tree node and stats
  * ~Rendered with tree using special character(e.g. `\t`)?~
  * Use protojson to structure node related values

```
$ spanner-cli -e "EXPLAIN ANALYZE SELECT * FROM Songs@{FORCE_INDEX=SongsBySongName}" --table
+-----------------------------------------------------------------------------+------+-------+---------+
| Query_Execution_Plan                                                        | Rows | Exec. | Latency |
+-----------------------------------------------------------------------------+------+-------+---------+
| .                                                                           |      |       |         |
| +- Distributed Union                                                        | 9    | 1     | 0.46    |
|     +- Distributed Cross Apply                                              | 9    | 1     | 0.44    |
|         +- [Input] Create Batch                                             |      |       |         |
|         |   +- Local Distributed Union                                      | 9    | 1     | 0.15    |
|         |       +- Compute Struct                                           | 9    | 1     | 0.14    |
|         |           +- Index Scan (Full scan: true, Index: SongsBySongName) | 9    | 1     | 0.1     |
|         +- [Map] Serialize Result                                           | 9    | 1     | 0.23    |
|             +- Cross Apply                                                  | 9    | 1     | 0.21    |
|                 +- [Input] Batch Scan (Batch: $v2)                          | 9    | 1     | 0.02    |
|                 +- [Map] Local Distributed Union                            | 9    | 9     | 0.19    |
|                     +- FilterScan                                           | 9    | 9     | 0.17    |
|                         +- Table Scan (Table: Songs)                        | 9    | 9     | 0.16    |
+-----------------------------------------------------------------------------+------+-------+---------+
9 rows in set (7.64 msecs)
timestamp: 2020-06-11T00:13:33.003192+09:00
cpu:       5.75 msecs
scanned:   18 rows
optimizer: 2
```
resolve #57 