### PR TITLE
Remove extra new lines for result of EXPLAIN statement

### DIFF
--- a/query_plan.go
+++ b/query_plan.go
@@ -79,7 +79,7 @@ func BuildQueryPlanTree(plan *pb.QueryPlan, idx int32) *Node {
 func (n *Node) Render() string {
 	tree := treeprint.New()
 	renderTree(tree, "", n)
-	return "\n" + tree.String()
+	return strings.TrimSuffix(tree.String(), "\n") // remove an extra new line appended to rendered tree
 }
 
 type RenderedTreeWithStats struct {


### PR DESCRIPTION
I found `EXPLAIN` statement shows extra new lines like this:

```
spanner> explain select 1;             
+-------------------------------------+
| Query_Execution_Plan (EXPERIMENTAL) |
+-------------------------------------+                                                                                                    
|                                     |                 
| .                                   |
| +- Serialize Result                 |
|     +- Unit Relation                |
|                                     |
+-------------------------------------+
1 rows in set (0.34 sec)
```

I don't remember why I appended new line for the result, but anyway now I removed those new lines so it can align with the result of `EXPLAIN ANALYZE` statement.

```
spanner> explain select 1;
+-------------------------------------+
| Query_Execution_Plan (EXPERIMENTAL) |
+-------------------------------------+
| .                                   |
| +- Serialize Result                 |
|     +- Unit Relation                |
+-------------------------------------+
1 rows in set (2.01 sec)

spanner> explain analyze select 1;
+----------------------+---------------+------------+---------------+
| Query_Execution_Plan | Rows_Returned | Executions | Total_Latency |
+----------------------+---------------+------------+---------------+
| .                    |               |            |               |
| +- Serialize Result  | 1             | 1          | 0.01 msecs    |
|     +- Unit Relation | 1             | 1          | 0 msecs       |
+----------------------+---------------+------------+---------------+
1 rows in set (2.8 msecs)
timestamp: 2020-06-16T20:10:20.939172+09:00
cpu:       1.06 msecs
scanned:   0 rows
optimizer: 2
```