### PR TITLE
Show predicates in EXPLAIN / EXPLAIN ANALYZE

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -370,6 +370,13 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, interactive, v
 		}
 	}
 
+	if len(result.Predicates) > 0 {
+		fmt.Fprintln(out, "Predicates(identified by ID):")
+		for _, s := range result.Predicates {
+			fmt.Fprintf(out, " %s\n", s)
+		}
+		fmt.Fprintln(out)
+	}
 	if result.ForceVerbose {
 		fmt.Fprint(out, resultLine(result, true))
 	} else if interactive {

--- a/query_plan.go
+++ b/query_plan.go
@@ -89,7 +89,7 @@ type RenderedTreeWithStats struct {
 	RowsTotal    string
 	Execution    string
 	LatencyTotal string
-	Children     []string
+	Predicates   []string
 }
 
 func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []RenderedTreeWithStats {
@@ -124,7 +124,8 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []RenderedTreeWithS
 		} else {
 			text = displayName
 		}
-		var children []string
+
+		var predicates []string
 		idx, _ := strconv.ParseInt(getStringValueByPath(value.GetStructValue(), "id"), 10, 0)
 
 		for _, cl := range planNodes[idx].GetChildLinks() {
@@ -132,15 +133,15 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []RenderedTreeWithS
 			if child.DisplayName != "Function" || !(cl.GetType() == "Residual Condition" || cl.GetType() == "Seek Condition" || cl.GetType() == "Split Range") {
 				continue
 			}
-			children = append(children, fmt.Sprintf("%s: %s", cl.GetType(), child.GetShortRepresentation().GetDescription()))
+			predicates = append(predicates, fmt.Sprintf("%s: %s", cl.GetType(), child.GetShortRepresentation().GetDescription()))
 		}
 
 		result = append(result, RenderedTreeWithStats{
-			ID:        fmt.Sprint(idx),
-			Children:  children,
-			Text:      branchText + text,
-			RowsTotal: getStringValueByPath(value.GetStructValue(), "execution_stats", "rows", "total"),
-			Execution: getStringValueByPath(value.GetStructValue(), "execution_stats", "execution_summary", "num_executions"),
+			ID:         fmt.Sprint(idx),
+			Predicates: predicates,
+			Text:       branchText + text,
+			RowsTotal:  getStringValueByPath(value.GetStructValue(), "execution_stats", "rows", "total"),
+			Execution:  getStringValueByPath(value.GetStructValue(), "execution_stats", "execution_summary", "num_executions"),
 			LatencyTotal: fmt.Sprintf("%s %s",
 				getStringValueByPath(value.GetStructValue(), "execution_stats", "latency", "total"),
 				getStringValueByPath(value.GetStructValue(), "execution_stats", "latency", "unit")),

--- a/query_plan.go
+++ b/query_plan.go
@@ -84,7 +84,7 @@ func BuildQueryPlanTree(plan *pb.QueryPlan, idx int32) *Node {
 }
 
 type QueryPlanRow struct {
-	ID           string
+	ID           int32
 	Text         string
 	RowsTotal    string
 	Execution    string
@@ -135,7 +135,7 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []QueryPlanRow {
 		}
 
 		result = append(result, QueryPlanRow{
-			ID:         fmt.Sprint(value.ID),
+			ID:         value.ID,
 			Predicates: predicates,
 			Text:       branchText + text,
 			RowsTotal:  getStringValueByPath(value.ExecutionStats.Struct, "rows", "total"),

--- a/query_plan.go
+++ b/query_plan.go
@@ -223,25 +223,8 @@ func (n *Node) String() string {
 	return operator + " " + metadata
 }
 
-func getStringValueByPath(s *structpb.Struct, first string, path ...string) string {
-	current := s.GetFields()[first]
-	for _, p := range path {
-		current = current.GetStructValue().GetFields()[p]
-	}
-	return current.GetStringValue()
-}
-
-// pbStruct is wrapper to implement json.Marshaller/json.Unmarshaller interfaces
+// pbStruct is wrapper to implement json.Marshaller interface
 type pbStruct struct{ *structpb.Struct }
-
-func (p *pbStruct) UnmarshalJSON(b []byte) error {
-	var ret structpb.Struct
-	if err := protojson.Unmarshal(b, &ret); err != nil {
-		return err
-	}
-	p.Struct = &ret
-	return nil
-}
 
 func (p *pbStruct) MarshalJSON() ([]byte, error) {
 	return protojson.Marshal(p.Struct)

--- a/query_plan.go
+++ b/query_plan.go
@@ -270,3 +270,14 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 		tree.AddNode(str)
 	}
 }
+
+func getMaxVisibleNodeID(planNodes []*pb.PlanNode) int32 {
+	var maxVisibleNodeID int32
+	for _, planNode := range planNodes {
+		if (&Node{PlanNode: planNode}).IsVisible() {
+			maxVisibleNodeID = planNode.Index
+		}
+	}
+	return maxVisibleNodeID
+}
+

--- a/query_plan.go
+++ b/query_plan.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/xlab/treeprint"
@@ -47,7 +46,7 @@ type Node struct {
 }
 
 type QueryPlanNodeWithStats struct {
-	ID             string    `json:"id"`
+	ID             int32     `json:"id"`
 	ExecutionStats *pbStruct `json:"execution_stats"`
 	DisplayName    string    `json:"display_name"`
 	LinkType       string    `json:"link_type"`
@@ -127,9 +126,7 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []RenderedTreeWithS
 		}
 
 		var predicates []string
-		idx, _ := strconv.ParseInt(value.ID, 10, 0)
-
-		for _, cl := range planNodes[idx].GetChildLinks() {
+		for _, cl := range planNodes[value.ID].GetChildLinks() {
 			child := planNodes[cl.ChildIndex]
 			if child.DisplayName != "Function" || !(cl.GetType() == "Residual Condition" || cl.GetType() == "Seek Condition" || cl.GetType() == "Split Range") {
 				continue
@@ -138,7 +135,7 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []RenderedTreeWithS
 		}
 
 		result = append(result, RenderedTreeWithStats{
-			ID:         fmt.Sprint(idx),
+			ID:         fmt.Sprint(value.ID),
 			Predicates: predicates,
 			Text:       branchText + text,
 			RowsTotal:  getStringValueByPath(value.ExecutionStats.Struct, "rows", "total"),
@@ -243,7 +240,7 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 
 	b, _ := json.Marshal(
 		QueryPlanNodeWithStats{
-			ID:             fmt.Sprint(node.PlanNode.Index),
+			ID:             node.PlanNode.Index,
 			ExecutionStats: &pbStruct{node.PlanNode.GetExecutionStats()},
 			DisplayName:    node.String(),
 			LinkType:       linkType,

--- a/query_plan.go
+++ b/query_plan.go
@@ -280,4 +280,3 @@ func getMaxVisibleNodeID(planNodes []*pb.PlanNode) int32 {
 	}
 	return maxVisibleNodeID
 }
-

--- a/query_plan.go
+++ b/query_plan.go
@@ -109,24 +109,21 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []QueryPlanRow {
 		}
 		branchText, protojsonText := split[0], split[1]
 
-		var value QueryPlanNodeWithStats
-		if err := json.Unmarshal([]byte(protojsonText), &value); err != nil {
+		var planNode QueryPlanNodeWithStats
+		if err := json.Unmarshal([]byte(protojsonText), &planNode); err != nil {
 			result = append(result, QueryPlanRow{Text: line})
 			continue
 		}
 
-		displayName := value.DisplayName
-		linkType := value.LinkType
-
 		var text string
-		if linkType != "" {
-			text = fmt.Sprintf("[%s] %s", linkType, displayName)
+		if planNode.LinkType != "" {
+			text = fmt.Sprintf("[%s] %s", planNode.LinkType, planNode.DisplayName)
 		} else {
-			text = displayName
+			text = planNode.DisplayName
 		}
 
 		var predicates []string
-		for _, cl := range planNodes[value.ID].GetChildLinks() {
+		for _, cl := range planNodes[planNode.ID].GetChildLinks() {
 			child := planNodes[cl.ChildIndex]
 			if child.DisplayName != "Function" || !(cl.GetType() == "Residual Condition" || cl.GetType() == "Seek Condition" || cl.GetType() == "Split Range") {
 				continue
@@ -135,14 +132,14 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []QueryPlanRow {
 		}
 
 		result = append(result, QueryPlanRow{
-			ID:         value.ID,
+			ID:         planNode.ID,
 			Predicates: predicates,
 			Text:       branchText + text,
-			RowsTotal:  getStringValueByPath(value.ExecutionStats.Struct, "rows", "total"),
-			Execution:  getStringValueByPath(value.ExecutionStats.Struct, "execution_summary", "num_executions"),
+			RowsTotal:  getStringValueByPath(planNode.ExecutionStats.Struct, "rows", "total"),
+			Execution:  getStringValueByPath(planNode.ExecutionStats.Struct, "execution_summary", "num_executions"),
 			LatencyTotal: fmt.Sprintf("%s %s",
-				getStringValueByPath(value.ExecutionStats.Struct, "latency", "total"),
-				getStringValueByPath(value.ExecutionStats.Struct, "latency", "unit")),
+				getStringValueByPath(planNode.ExecutionStats.Struct, "latency", "total"),
+				getStringValueByPath(planNode.ExecutionStats.Struct, "latency", "unit")),
 		})
 	}
 	return result

--- a/query_plan.go
+++ b/query_plan.go
@@ -77,12 +77,6 @@ func BuildQueryPlanTree(plan *pb.QueryPlan, idx int32) *Node {
 	return root
 }
 
-func (n *Node) Render() string {
-	tree := treeprint.New()
-	renderTree(tree, "", n)
-	return strings.TrimSuffix(tree.String(), "\n") // remove an extra new line appended to rendered tree
-}
-
 type RenderedTreeWithStats struct {
 	ID           string
 	Text         string
@@ -209,32 +203,6 @@ func (n *Node) String() string {
 		return operator
 	}
 	return operator + " " + metadata
-}
-
-func renderTree(tree treeprint.Tree, linkType string, node *Node) {
-	if !node.IsVisible() {
-		return
-	}
-
-	str := node.String()
-
-	if len(node.Children) > 0 {
-		var branch treeprint.Tree
-		if linkType != "" {
-			branch = tree.AddMetaBranch(linkType, str)
-		} else {
-			branch = tree.AddBranch(str)
-		}
-		for _, child := range node.Children {
-			renderTree(branch, child.Type, child.Dest)
-		}
-	} else {
-		if linkType != "" {
-			tree.AddMetaNode(linkType, str)
-		} else {
-			tree.AddNode(str)
-		}
-	}
 }
 
 func getStringValueByPath(s *structpb.Struct, first string, path ...string) string {

--- a/query_plan.go
+++ b/query_plan.go
@@ -83,7 +83,7 @@ func BuildQueryPlanTree(plan *pb.QueryPlan, idx int32) *Node {
 	return root
 }
 
-type RenderedTreeWithStats struct {
+type QueryPlanRow struct {
 	ID           string
 	Text         string
 	RowsTotal    string
@@ -92,10 +92,10 @@ type RenderedTreeWithStats struct {
 	Predicates   []string
 }
 
-func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []RenderedTreeWithStats {
+func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []QueryPlanRow {
 	tree := treeprint.New()
 	renderTreeWithStats(tree, "", n)
-	var result []RenderedTreeWithStats
+	var result []QueryPlanRow
 	for _, line := range strings.Split(tree.String(), "\n") {
 		if line == "" {
 			continue
@@ -104,14 +104,14 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []RenderedTreeWithS
 		split := strings.SplitN(line, "\t", 2)
 		// Handle the case of the root node of treeprint
 		if len(split) != 2 {
-			result = append(result, RenderedTreeWithStats{Text: line})
+			result = append(result, QueryPlanRow{Text: line})
 			continue
 		}
 		branchText, protojsonText := split[0], split[1]
 
 		var value QueryPlanNodeWithStats
 		if err := json.Unmarshal([]byte(protojsonText), &value); err != nil {
-			result = append(result, RenderedTreeWithStats{Text: line})
+			result = append(result, QueryPlanRow{Text: line})
 			continue
 		}
 
@@ -134,7 +134,7 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []RenderedTreeWithS
 			predicates = append(predicates, fmt.Sprintf("%s: %s", cl.GetType(), child.GetShortRepresentation().GetDescription()))
 		}
 
-		result = append(result, RenderedTreeWithStats{
+		result = append(result, QueryPlanRow{
 			ID:         fmt.Sprint(value.ID),
 			Predicates: predicates,
 			Text:       branchText + text,

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -29,10 +29,9 @@ func TestRenderTreeWithStats(t *testing.T) {
 			plan: &spanner.QueryPlan{
 				PlanNodes: []*spanner.PlanNode{
 					{
+						Index: 0,
 						ChildLinks: []*spanner.PlanNode_ChildLink{
-							{
-								ChildIndex: 1,
-							},
+							{ChildIndex: 1},
 						},
 						DisplayName: "Distributed Union",
 						Kind:        spanner.PlanNode_RELATIONAL,
@@ -44,10 +43,9 @@ func TestRenderTreeWithStats(t *testing.T) {
 }`),
 					},
 					{
+						Index: 1,
 						ChildLinks: []*spanner.PlanNode_ChildLink{
-							{
-								ChildIndex: 2,
-							},
+							{ChildIndex: 2},
 						},
 						DisplayName: "Distributed Union",
 						Kind:        spanner.PlanNode_RELATIONAL,
@@ -60,10 +58,9 @@ func TestRenderTreeWithStats(t *testing.T) {
 }`),
 					},
 					{
+						Index: 2,
 						ChildLinks: []*spanner.PlanNode_ChildLink{
-							{
-								ChildIndex: 3,
-							},
+							{ChildIndex: 3},
 						},
 						DisplayName: "Serialize Result",
 						Kind:        spanner.PlanNode_RELATIONAL,
@@ -75,6 +72,7 @@ func TestRenderTreeWithStats(t *testing.T) {
 }`),
 					},
 					{
+						Index:       3,
 						DisplayName: "Scan",
 						Kind:        spanner.PlanNode_RELATIONAL,
 						Metadata:    protojsonAsStruct(t, `{"scan_type": "IndexScan", "scan_target": "SongsBySingerAlbumSongNameDesc", "Full scan": "true"}`),
@@ -90,24 +88,28 @@ func TestRenderTreeWithStats(t *testing.T) {
 			want: []RenderedTreeWithStats{
 				{Text: "."},
 				{
+					ID:           "0",
 					Text:         "+- Distributed Union",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
 				{
+					ID:           "1",
 					Text:         "    +- Local Distributed Union",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
 				{
+					ID:           "2",
 					Text:         "        +- Serialize Result",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
 				{
+					ID:           "3",
 					Text:         "            +- Index Scan (Full scan: true, Index: SongsBySingerAlbumSongNameDesc)",
 					RowsTotal:    "9",
 					Execution:    "1",

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -22,7 +22,7 @@ func TestRenderTreeWithStats(t *testing.T) {
 	for _, test := range []struct {
 		title string
 		plan  *spanner.QueryPlan
-		want  []RenderedTreeWithStats
+		want  []QueryPlanRow
 	}{
 		{
 			title: "Simple Query",
@@ -85,7 +85,7 @@ func TestRenderTreeWithStats(t *testing.T) {
 					},
 				},
 			},
-			want: []RenderedTreeWithStats{
+			want: []QueryPlanRow{
 				{Text: "."},
 				{
 					ID:           "0",

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -24,7 +24,8 @@ func TestRenderTreeWithStats(t *testing.T) {
 		plan  *spanner.QueryPlan
 		want  []RenderedTreeWithStats
 	}{
-		{title: "Simple Query",
+		{
+			title: "Simple Query",
 			plan: &spanner.QueryPlan{
 				PlanNodes: []*spanner.PlanNode{
 					{
@@ -115,7 +116,7 @@ func TestRenderTreeWithStats(t *testing.T) {
 			}},
 	} {
 		tree := BuildQueryPlanTree(test.plan, 0)
-		if got := tree.RenderTreeWithStats(); !cmp.Equal(test.want, got) {
+		if got := tree.RenderTreeWithStats(test.plan.GetPlanNodes()); !cmp.Equal(test.want, got) {
 			t.Errorf("%s: node.RenderTreeWithStats() differ: %s", test.title, cmp.Diff(test.want, got))
 		}
 	}

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -88,28 +88,28 @@ func TestRenderTreeWithStats(t *testing.T) {
 			want: []QueryPlanRow{
 				{Text: "."},
 				{
-					ID:           "0",
+					ID:           0,
 					Text:         "+- Distributed Union",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
 				{
-					ID:           "1",
+					ID:           1,
 					Text:         "    +- Local Distributed Union",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
 				{
-					ID:           "2",
+					ID:           2,
 					Text:         "        +- Serialize Result",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
 				{
-					ID:           "3",
+					ID:           3,
 					Text:         "            +- Index Scan (Full scan: true, Index: SongsBySingerAlbumSongNameDesc)",
 					RowsTotal:    "9",
 					Execution:    "1",

--- a/statement.go
+++ b/statement.go
@@ -526,20 +526,20 @@ func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
 	maxWidthOfNodeID := len(fmt.Sprint(getMaxVisibleNodeID(planNodes)))
 	for _, row := range tree.RenderTreeWithStats(planNodes) {
 		var formattedID string
-		if len(row.Children) > 0 {
+		if len(row.Predicates) > 0 {
 			formattedID = fmt.Sprintf("%*s", maxWidthOfNodeID+1, "*"+row.ID)
 		} else {
 			formattedID = fmt.Sprintf("%*s", maxWidthOfNodeID+1, row.ID)
 		}
 		result.Rows = append(result.Rows, Row{[]string{formattedID, row.Text, row.RowsTotal, row.Execution, row.LatencyTotal}})
-		for i, child := range row.Children {
+		for i, predicate := range row.Predicates {
 			var prefix string
 			if i == 0 {
 				prefix = fmt.Sprintf("%*s:", maxWidthOfNodeID, row.ID)
 			} else {
 				prefix = strings.Repeat(" ", maxWidthOfNodeID+1)
 			}
-			result.Predicates = append(result.Predicates, fmt.Sprintf("%s %s", prefix, child))
+			result.Predicates = append(result.Predicates, fmt.Sprintf("%s %s", prefix, predicate))
 		}
 	}
 

--- a/statement.go
+++ b/statement.go
@@ -535,7 +535,6 @@ func processPlanWithoutStats(plan *pb.QueryPlan) (rows []Row, predicates []strin
 	return processPlanImpl(plan, false)
 }
 
-
 func processPlanImpl(plan *pb.QueryPlan, withStats bool) (rows []Row, predicates []string) {
 	planNodes := plan.GetPlanNodes()
 	maxWidthOfNodeID := len(fmt.Sprint(getMaxVisibleNodeID(planNodes)))

--- a/statement.go
+++ b/statement.go
@@ -471,15 +471,15 @@ func (s *ExplainStatement) Execute(session *Session) (*Result, error) {
 	for _, row := range tree.RenderTreeWithStats(planNodes) {
 		var formattedID string
 		if len(row.Predicates) > 0 {
-			formattedID = fmt.Sprintf("%*s", maxWidthOfNodeID+1, "*"+row.ID)
+			formattedID = fmt.Sprintf("%*s", maxWidthOfNodeID+1, "*"+fmt.Sprint(row.ID))
 		} else {
-			formattedID = fmt.Sprintf("%*s", maxWidthOfNodeID+1, row.ID)
+			formattedID = fmt.Sprintf("%*d", maxWidthOfNodeID+1, row.ID)
 		}
 		rows = append(rows, Row{[]string{formattedID, row.Text}})
 		for i, predicate := range row.Predicates {
 			var prefix string
 			if i == 0 {
-				prefix = fmt.Sprintf("%*s:", maxWidthOfNodeID, row.ID)
+				prefix = fmt.Sprintf("%*d:", maxWidthOfNodeID, row.ID)
 			} else {
 				prefix = strings.Repeat(" ", maxWidthOfNodeID+1)
 			}
@@ -539,15 +539,15 @@ func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
 	for _, row := range tree.RenderTreeWithStats(planNodes) {
 		var formattedID string
 		if len(row.Predicates) > 0 {
-			formattedID = fmt.Sprintf("%*s", maxWidthOfNodeID+1, "*"+row.ID)
+			formattedID = fmt.Sprintf("%*s", maxWidthOfNodeID, "*"+fmt.Sprint(row.ID))
 		} else {
-			formattedID = fmt.Sprintf("%*s", maxWidthOfNodeID+1, row.ID)
+			formattedID = fmt.Sprintf("%*d", maxWidthOfNodeID+1, row.ID)
 		}
 		rows = append(rows, Row{[]string{formattedID, row.Text, row.RowsTotal, row.Execution, row.LatencyTotal}})
 		for i, predicate := range row.Predicates {
 			var prefix string
 			if i == 0 {
-				prefix = fmt.Sprintf("%*s:", maxWidthOfNodeID, row.ID)
+				prefix = fmt.Sprintf("%*d:", maxWidthOfNodeID, row.ID)
 			} else {
 				prefix = strings.Repeat(" ", maxWidthOfNodeID+1)
 			}

--- a/statement.go
+++ b/statement.go
@@ -523,7 +523,7 @@ func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
 	}
 
 	planNodes := iter.QueryPlan.GetPlanNodes()
-	maxWidthOfNodeID := len(fmt.Sprint(len(planNodes)))
+	maxWidthOfNodeID := len(fmt.Sprint(getMaxVisibleNodeID(planNodes)))
 	for _, row := range tree.RenderTreeWithStats(planNodes) {
 		var formattedID string
 		if len(row.Children) > 0 {


### PR DESCRIPTION
This PR implements showing predicates in `EXPLAIN ANALYZE` and `EXPLAIN`.

## Example

```sql
EXPLAIN ANALYZE
SELECT * FROM (
  SELECT c.*
  FROM UNNEST(GENERATE_ARRAY(0, 9)) AS OneShardCreatedAt,
      UNNEST(ARRAY(
         SELECT AS STRUCT OrderId, CreatedAt
         FROM Order1M@{FORCE_INDEX=Order1MShardCreatedAtDesc}
         WHERE ShardCreatedAt = OneShardCreatedAt
         ORDER BY CreatedAt DESC LIMIT 10
      )) AS c
  ORDER BY c.CreatedAt DESC
  LIMIT 10
)
INNER JOIN Order1M USING(OrderId)
```

### `EXPLAIN` with `--table`

```
+-----+----------------------------------------------------------------------------------------------+
| ID  | Query_Execution_Plan (EXPERIMENTAL)                                                          |
+-----+----------------------------------------------------------------------------------------------+
|     | .                                                                                            |
|   0 | +- Global Limit                                                                              |
|  *1 |     +- Distributed Cross Apply                                                               |
|   2 |         +- [Input] Create Batch                                                              |
|   3 |         |   +- Compute Struct                                                                |
|   4 |         |       +- Local Sort Limit                                                          |
|   5 |         |           +- Cross Apply                                                           |
|   6 |         |               +- [Input] Array Unnest                                              |
|  11 |         |               +- [Map] Global Limit                                                |
| *12 |         |                   +- Distributed Union                                             |
|  13 |         |                       +- Local Limit                                               |
|  14 |         |                           +- Local Distributed Union                               |
| *15 |         |                               +- FilterScan                                        |
|  16 |         |                                   +- Index Scan (Index: Order1MShardCreatedAtDesc) |
|  37 |         +- [Map] Serialize Result                                                            |
|  38 |             +- MiniBatchKeyOrder                                                             |
|  39 |                 +- Minor Sort Limit                                                          |
|  40 |                     +- RowCount                                                              |
|  41 |                         +- Cross Apply                                                       |
|  42 |                             +- [Input] RowCount                                              |
|  43 |                             |   +- Local Minor Sort                                          |
|  44 |                             |       +- MiniBatchAssign                                       |
|  45 |                             |           +- Batch Scan (Batch: $v2)                           |
|  56 |                             +- [Map] Local Distributed Union                                 |
| *57 |                                 +- FilterScan                                                |
|  58 |                                     +- Table Scan (Table: Order1M)                           |
+-----+----------------------------------------------------------------------------------------------+
Predicates(identified by ID):
  1: Split Range: ($OrderId_4 = $sort_OrderId)
 12: Split Range: ($ShardCreatedAt = $OneShardCreatedAt)
 15: Seek Condition: ($ShardCreatedAt = $OneShardCreatedAt)
 57: Seek Condition: ($OrderId_4 = $sort_batched_OrderId)

```

### `EXPLAIN` without `--table`

```
ID      Query_Execution_Plan (EXPERIMENTAL)
        .
  0     +- Global Limit
 *1         +- Distributed Cross Apply
  2             +- [Input] Create Batch
  3             |   +- Compute Struct
  4             |       +- Local Sort Limit
  5             |           +- Cross Apply
  6             |               +- [Input] Array Unnest
 11             |               +- [Map] Global Limit
*12             |                   +- Distributed Union
 13             |                       +- Local Limit
 14             |                           +- Local Distributed Union
*15             |                               +- FilterScan
 16             |                                   +- Index Scan (Index: Order1MShardCreatedAtDesc)
 37             +- [Map] Serialize Result
 38                 +- MiniBatchKeyOrder
 39                     +- Minor Sort Limit
 40                         +- RowCount
 41                             +- Cross Apply
 42                                 +- [Input] RowCount
 43                                 |   +- Local Minor Sort
 44                                 |       +- MiniBatchAssign
 45                                 |           +- Batch Scan (Batch: $v2)
 56                                 +- [Map] Local Distributed Union
*57                                     +- FilterScan
 58                                         +- Table Scan (Table: Order1M)
Predicates(identified by ID):
  1: Split Range: ($OrderId_4 = $sort_OrderId)
 12: Split Range: ($ShardCreatedAt = $OneShardCreatedAt)
 15: Seek Condition: ($ShardCreatedAt = $OneShardCreatedAt)
 57: Seek Condition: ($OrderId_4 = $sort_batched_OrderId)

```

### `EXPLAIN ANALYZE` with `--table`
```
+-----+----------------------------------------------------------------------------------------------+---------------+------------+---------------+
| ID  | Query_Execution_Plan                                                                         | Rows_Returned | Executions | Total_Latency |
+-----+----------------------------------------------------------------------------------------------+---------------+------------+---------------+
|     | .                                                                                            |               |            |               |
|   0 | +- Global Limit                                                                              | 10            | 1          | 136.15 msecs  |
|  *1 |     +- Distributed Cross Apply                                                               | 10            | 1          | 136.15 msecs  |
|   2 |         +- [Input] Create Batch                                                              |               |            |               |
|   3 |         |   +- Compute Struct                                                                | 10            | 1          | 65.12 msecs   |
|   4 |         |       +- Local Sort Limit                                                          | 10            | 1          | 65.11 msecs   |
|   5 |         |           +- Cross Apply                                                           | 100           | 1          | 64.94 msecs   |
|   6 |         |               +- [Input] Array Unnest                                              | 10            | 1          | 0.08 msecs    |
|  11 |         |               +- [Map] Global Limit                                                | 100           | 10         | 64.81 msecs   |
| *12 |         |                   +- Distributed Union                                             | 100           | 10         | 64.78 msecs   |
|  13 |         |                       +- Local Limit                                               | 100           | 10         | 64.43 msecs   |
|  14 |         |                           +- Local Distributed Union                               | 100           | 10         | 64.4 msecs    |
| *15 |         |                               +- FilterScan                                        |               |            |               |
|  16 |         |                                   +- Index Scan (Index: Order1MShardCreatedAtDesc) | 100           | 10         | 62.75 msecs   |
|  37 |         +- [Map] Serialize Result                                                            | 10            | 7          | 97.94 msecs   |
|  38 |             +- MiniBatchKeyOrder                                                             |               |            |               |
|  39 |                 +- Minor Sort Limit                                                          | 10            | 7          | 97.83 msecs   |
|  40 |                     +- RowCount                                                              |               |            |               |
|  41 |                         +- Cross Apply                                                       | 10            | 7          | 97.62 msecs   |
|  42 |                             +- [Input] RowCount                                              |               |            |               |
|  43 |                             |   +- Local Minor Sort                                          | 10            | 7          | 0.21 msecs    |
|  44 |                             |       +- MiniBatchAssign                                       |               |            |               |
|  45 |                             |           +- Batch Scan (Batch: $v2)                           | 10            | 7          | 0.05 msecs    |
|  56 |                             +- [Map] Local Distributed Union                                 | 10            | 10         | 97.39 msecs   |
| *57 |                                 +- FilterScan                                                | 10            | 10         | 97.27 msecs   |
|  58 |                                     +- Table Scan (Table: Order1M)                           | 10            | 10         | 97.23 msecs   |
+-----+----------------------------------------------------------------------------------------------+---------------+------------+---------------+
Predicates(identified by ID):
  1: Split Range: ($OrderId_4 = $sort_OrderId)
 12: Split Range: ($ShardCreatedAt = $OneShardCreatedAt)
 15: Seek Condition: ($ShardCreatedAt = $OneShardCreatedAt)
 57: Seek Condition: ($OrderId_4 = $sort_batched_OrderId)

10 rows in set (155.82 msecs)
timestamp: 2020-06-17T18:20:10.399811+09:00
cpu:       188.75 msecs
scanned:   110 rows
optimizer: 2
```

### `EXPLAIN ANALYZE` without `--table`

```
ID      Query_Execution_Plan    Rows_Returned   Executions      Total_Latency
        .                       
  0     +- Global Limit 10      1       50.49 msecs
 *1         +- Distributed Cross Apply  10      1       50.49 msecs
  2             +- [Input] Create Batch                  
  3             |   +- Compute Struct   10      1       1.74 msecs
  4             |       +- Local Sort Limit     10      1       1.73 msecs
  5             |           +- Cross Apply      100     1       1.66 msecs
  6             |               +- [Input] Array Unnest 10      1       0.02 msecs
 11             |               +- [Map] Global Limit   100     10      1.62 msecs
*12             |                   +- Distributed Union        100     10      1.61 msecs
 13             |                       +- Local Limit  100     10      1.51 msecs
 14             |                           +- Local Distributed Union  100     10      1.49 msecs
*15             |                               +- FilterScan                    
 16             |                                   +- Index Scan (Index: Order1MShardCreatedAtDesc)    100     10      1.36 msecs
 37             +- [Map] Serialize Result       10      7       61.52 msecs
 38                 +- MiniBatchKeyOrder                         
 39                     +- Minor Sort Limit     10      7       61.47 msecs
 40                         +- RowCount                  
 41                             +- Cross Apply  10      7       61.33 msecs
 42                                 +- [Input] RowCount                  
 43                                 |   +- Local Minor Sort     10      7       0.15 msecs
 44                                 |       +- MiniBatchAssign                   
 45                                 |           +- Batch Scan (Batch: $v2)      10      7       0.03 msecs
 56                                 +- [Map] Local Distributed Union    10      10      61.16 msecs
*57                                     +- FilterScan   10      10      61.07 msecs
 58                                         +- Table Scan (Table: Order1M)      10      10      61.04 msecs
Predicates(identified by ID):
  1: Split Range: ($OrderId_4 = $sort_OrderId)
 12: Split Range: ($ShardCreatedAt = $OneShardCreatedAt)
 15: Seek Condition: ($ShardCreatedAt = $OneShardCreatedAt)
 57: Seek Condition: ($OrderId_4 = $sort_batched_OrderId)

10 rows in set (64.81 msecs)
timestamp: 2020-06-17T18:27:54.865928+09:00
cpu:       109.07 msecs
scanned:   110 rows
optimizer: 2

```

### `EXPLAIN ANALYZE` with `\G`

It seems not good to me. Should it be forbid or force horizontal or tab style?

<details>

```
*************************** 1. row ***************************
                  ID:    
Query_Execution_Plan: .
       Rows_Returned: 
          Executions: 
       Total_Latency: 
*************************** 2. row ***************************
                  ID:   0
Query_Execution_Plan: +- Global Limit
       Rows_Returned: 10
          Executions: 1
       Total_Latency: 16.69 msecs
*************************** 3. row ***************************
                  ID:  *1
Query_Execution_Plan:     +- Distributed Cross Apply
       Rows_Returned: 10
          Executions: 1
       Total_Latency: 16.69 msecs
*************************** 4. row ***************************
                  ID:   2
Query_Execution_Plan:         +- [Input] Create Batch
       Rows_Returned: 
          Executions: 
       Total_Latency:  
*************************** 5. row ***************************
                  ID:   3
Query_Execution_Plan:         |   +- Compute Struct
       Rows_Returned: 10
          Executions: 1
       Total_Latency: 1.13 msecs
*************************** 6. row ***************************
                  ID:   4
Query_Execution_Plan:         |       +- Local Sort Limit
       Rows_Returned: 10
          Executions: 1
       Total_Latency: 1.13 msecs
*************************** 7. row ***************************
                  ID:   5
Query_Execution_Plan:         |           +- Cross Apply
       Rows_Returned: 100
          Executions: 1
       Total_Latency: 1.08 msecs
*************************** 8. row ***************************
                  ID:   6
Query_Execution_Plan:         |               +- [Input] Array Unnest
       Rows_Returned: 10
          Executions: 1
       Total_Latency: 0.02 msecs
*************************** 9. row ***************************
                  ID:  11
Query_Execution_Plan:         |               +- [Map] Global Limit
       Rows_Returned: 100
          Executions: 10
       Total_Latency: 1.05 msecs
*************************** 10. row ***************************
                  ID: *12
Query_Execution_Plan:         |                   +- Distributed Union
       Rows_Returned: 100
          Executions: 10
       Total_Latency: 1.04 msecs
*************************** 11. row ***************************
                  ID:  13
Query_Execution_Plan:         |                       +- Local Limit
       Rows_Returned: 100
          Executions: 10
       Total_Latency: 0.98 msecs
*************************** 12. row ***************************
                  ID:  14
Query_Execution_Plan:         |                           +- Local Distributed Union
       Rows_Returned: 100
          Executions: 10
       Total_Latency: 0.97 msecs
*************************** 13. row ***************************
                  ID: *15
Query_Execution_Plan:         |                               +- FilterScan
       Rows_Returned: 
          Executions: 
       Total_Latency:  
*************************** 14. row ***************************
                  ID:  16
Query_Execution_Plan:         |                                   +- Index Scan (Index: Order1MShardCreatedAtDesc)
       Rows_Returned: 100
          Executions: 10
       Total_Latency: 0.85 msecs
*************************** 15. row ***************************
                  ID:  37
Query_Execution_Plan:         +- [Map] Serialize Result
       Rows_Returned: 10
          Executions: 7
       Total_Latency: 28.86 msecs
*************************** 16. row ***************************
                  ID:  38
Query_Execution_Plan:             +- MiniBatchKeyOrder
       Rows_Returned: 
          Executions: 
       Total_Latency:  
*************************** 17. row ***************************
                  ID:  39
Query_Execution_Plan:                 +- Minor Sort Limit
       Rows_Returned: 10
          Executions: 7
       Total_Latency: 28.81 msecs
*************************** 18. row ***************************
                  ID:  40
Query_Execution_Plan:                     +- RowCount
       Rows_Returned: 
          Executions: 
       Total_Latency:  
*************************** 19. row ***************************
                  ID:  41
Query_Execution_Plan:                         +- Cross Apply
       Rows_Returned: 10
          Executions: 7
       Total_Latency: 28.67 msecs
*************************** 20. row ***************************
                  ID:  42
Query_Execution_Plan:                             +- [Input] RowCount
       Rows_Returned: 
          Executions: 
       Total_Latency:  
*************************** 21. row ***************************
                  ID:  43
Query_Execution_Plan:                             |   +- Local Minor Sort
       Rows_Returned: 10
          Executions: 7
       Total_Latency: 0.13 msecs
*************************** 22. row ***************************
                  ID:  44
Query_Execution_Plan:                             |       +- MiniBatchAssign
       Rows_Returned: 
          Executions: 
       Total_Latency:  
*************************** 23. row ***************************
                  ID:  45
Query_Execution_Plan:                             |           +- Batch Scan (Batch: $v2)
       Rows_Returned: 10
          Executions: 7
       Total_Latency: 0.03 msecs
*************************** 24. row ***************************
                  ID:  56
Query_Execution_Plan:                             +- [Map] Local Distributed Union
       Rows_Returned: 10
          Executions: 10
       Total_Latency: 28.52 msecs
*************************** 25. row ***************************
                  ID: *57
Query_Execution_Plan:                                 +- FilterScan
       Rows_Returned: 10
          Executions: 10
       Total_Latency: 28.44 msecs
*************************** 26. row ***************************
                  ID:  58
Query_Execution_Plan:                                     +- Table Scan (Table: Order1M)
       Rows_Returned: 10
          Executions: 10
       Total_Latency: 28.42 msecs
Predicates(identified by ID):
  1: Split Range: ($OrderId_4 = $sort_OrderId)
 12: Split Range: ($ShardCreatedAt = $OneShardCreatedAt)
 15: Seek Condition: ($ShardCreatedAt = $OneShardCreatedAt)
 57: Seek Condition: ($OrderId_4 = $sort_batched_OrderId)

10 rows in set (28.39 msecs)
timestamp: 2020-06-17T18:29:32.885306+09:00
cpu:       19.67 msecs
scanned:   110 rows
optimizer: 2
```

</details>

close #69 