### PR TITLE
Fix to make ID of root line empty in EXPLAIN and EXPLAIN ANALYZE

### DIFF
--- a/query_plan.go
+++ b/query_plan.go
@@ -109,6 +109,7 @@ type QueryPlanRow struct {
 	Execution    string
 	LatencyTotal string
 	Predicates   []string
+	TextOnly     bool
 }
 
 func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []QueryPlanRow {
@@ -123,14 +124,14 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []QueryPlanRow {
 		split := strings.SplitN(line, "\t", 2)
 		// Handle the case of the root node of treeprint
 		if len(split) != 2 {
-			result = append(result, QueryPlanRow{Text: line})
+			result = append(result, QueryPlanRow{Text: line, TextOnly: true})
 			continue
 		}
 		branchText, protojsonText := split[0], split[1]
 
 		var planNode queryPlanNodeWithStatsTyped
 		if err := json.Unmarshal([]byte(protojsonText), &planNode); err != nil {
-			result = append(result, QueryPlanRow{Text: line})
+			result = append(result, QueryPlanRow{Text: line, TextOnly: true})
 			continue
 		}
 

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -86,7 +86,7 @@ func TestRenderTreeWithStats(t *testing.T) {
 				},
 			},
 			want: []QueryPlanRow{
-				{Text: "."},
+				{Text: ".", TextOnly: true},
 				{
 					ID:           0,
 					Text:         "+- Distributed Union",

--- a/statement.go
+++ b/statement.go
@@ -543,7 +543,9 @@ func processPlanImpl(plan *pb.QueryPlan, withStats bool) (rows []Row, predicates
 
 	for _, row := range tree.RenderTreeWithStats(planNodes) {
 		var formattedID string
-		if len(row.Predicates) > 0 {
+		if row.TextOnly {
+			formattedID = strings.Repeat(" ", maxWidthOfNodeID+1)
+		} else if len(row.Predicates) > 0 {
 			formattedID = fmt.Sprintf("%*s", maxWidthOfNodeID, "*"+fmt.Sprint(row.ID))
 		} else {
 			formattedID = fmt.Sprintf("%*d", maxWidthOfNodeID+1, row.ID)


### PR DESCRIPTION
ID of the root line shows `0` but it is wrong.

```
$ spanner-cli -e "EXPLAIN SELECT 1" -t
+----+-------------------------------------+
| ID | Query_Execution_Plan (EXPERIMENTAL) |
+----+-------------------------------------+
|  0 | .                                   |
|  0 | +- Serialize Result                 |
|  1 |     +- Unit Relation                |
+----+-------------------------------------+
```
Expected result is
```
$ spanner-cli -e "EXPLAIN SELECT 1" -t
+----+-------------------------------------+
| ID | Query_Execution_Plan (EXPERIMENTAL) |
+----+-------------------------------------+
|    | .                                   |
|  0 | +- Serialize Result                 |
|  1 |     +- Unit Relation                |
+----+-------------------------------------+
```

(It can implemented like `ID: -1` rather than `TextOnly: true` but I don't want to add another meaning to ID field.)