### PR TITLE
Hide Array Constructor operator

### DIFF
--- a/query_plan.go
+++ b/query_plan.go
@@ -165,7 +165,7 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) []QueryPlanRow {
 
 func (n *Node) IsVisible() bool {
 	operator := n.PlanNode.DisplayName
-	if operator == "Function" || operator == "Reference" || operator == "Constant" {
+	if operator == "Function" || operator == "Reference" || operator == "Constant" || operator == "Array Constructor" {
 		return false
 	}
 


### PR DESCRIPTION
This PR hide `Array Constructor` to achieve better consistency.

## Current behavior

Currently, `Array Constructor` operator is shown as tree node.
```
$ spanner-cli -e "EXPLAIN SELECT a, b FROM UNNEST([1,2,3]) a WITH OFFSET b;" -t
+----+-------------------------------------+
| ID | Query_Execution_Plan (EXPERIMENTAL) |
+----+-------------------------------------+
|    | .                                   |
|  0 | +- Serialize Result                 |
|  1 |     +- Array Unnest                 |
|  2 |         +- Array Constructor        |
+----+-------------------------------------+
```

but it is a non-subquery scalar operator and it is usually hidden in visualization.

For examples, the document of same query in [Array unnest of Query execution operators](https://cloud.google.com/spanner/docs/query-execution-operators?hl=en#array-unnest) and query plan in GCP console don't show the operator.

<img width="437" src="https://user-images.githubusercontent.com/803393/85223131-6459ee80-b3fb-11ea-8903-8c8d03e6997a.png">

## Behavior after this PR

```
+----+-------------------------------------+
| ID | Query_Execution_Plan (EXPERIMENTAL) |
+----+-------------------------------------+
|    | .                                   |
|  0 | +- Serialize Result                 |
|  1 |     +- Array Unnest                 |
+----+-------------------------------------+
```