### PR TITLE
Simplify use of structpb using protobuf-go v1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,13 @@ require (
 	cloud.google.com/go v0.56.0
 	cloud.google.com/go/spanner v1.5.1
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
-	github.com/google/go-cmp v0.4.0
+	github.com/google/go-cmp v0.5.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/mattn/go-runewidth v0.0.8 // indirect
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/xlab/treeprint v1.0.0
 	google.golang.org/api v0.21.0
-	google.golang.org/genproto v0.0.0-20200416231807-8751e049a2a0
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.28.1
-	google.golang.org/protobuf v1.21.0
+	google.golang.org/protobuf v1.25.0
 )

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
+github.com/golang/protobuf v1.4.1 h1:ZFgWrT+bLgsYPirOnRfKLYJLvssAegOj/hgyMFdJZe0=
+github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -86,6 +88,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -323,6 +327,8 @@ google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200409111301-baae70f3302d/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200416231807-8751e049a2a0 h1:N5O9PpTbQrkvH0IQ1q+mmGyg8Gt6iKcu6b6+gmz3jnA=
 google.golang.org/genproto v0.0.0-20200416231807-8751e049a2a0/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
+google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -341,6 +347,10 @@ google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQ
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
 google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
+google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
+google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/query_plan.go
+++ b/query_plan.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/xlab/treeprint"
 	pb "google.golang.org/genproto/googleapis/spanner/v1"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -47,7 +46,7 @@ type Node struct {
 
 type QueryPlanNodeWithStats struct {
 	ID             int32     `json:"id"`
-	ExecutionStats *pbStruct `json:"execution_stats"`
+	ExecutionStats *structpb.Struct `json:"execution_stats"`
 	DisplayName    string    `json:"display_name"`
 	LinkType       string    `json:"link_type"`
 }
@@ -224,13 +223,6 @@ func (n *Node) String() string {
 	return operator + " " + metadata
 }
 
-// pbStruct is wrapper to implement json.Marshaller interface
-type pbStruct struct{ *structpb.Struct }
-
-func (p *pbStruct) MarshalJSON() ([]byte, error) {
-	return protojson.Marshal(p.Struct)
-}
-
 func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 	if !node.IsVisible() {
 		return
@@ -239,7 +231,7 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 	b, _ := json.Marshal(
 		QueryPlanNodeWithStats{
 			ID:             node.PlanNode.Index,
-			ExecutionStats: &pbStruct{node.PlanNode.GetExecutionStats()},
+			ExecutionStats: node.PlanNode.GetExecutionStats(),
 			DisplayName:    node.String(),
 			LinkType:       linkType,
 		},

--- a/query_plan.go
+++ b/query_plan.go
@@ -45,10 +45,10 @@ type Node struct {
 }
 
 type QueryPlanNodeWithStats struct {
-	ID             int32     `json:"id"`
+	ID             int32            `json:"id"`
 	ExecutionStats *structpb.Struct `json:"execution_stats"`
-	DisplayName    string    `json:"display_name"`
-	LinkType       string    `json:"link_type"`
+	DisplayName    string           `json:"display_name"`
+	LinkType       string           `json:"link_type"`
 }
 
 type executionStatsValue struct {

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -18,6 +18,13 @@ func protojsonAsStruct(t *testing.T, j string) *structpb.Struct {
 	return &result
 }
 
+func mustNewStruct(m map[string]interface{}) *structpb.Struct {
+	if s, err := structpb.NewStruct(m); err != nil {
+		panic(err)
+	} else {
+		return s
+	}
+}
 func TestRenderTreeWithStats(t *testing.T) {
 	for _, test := range []struct {
 		title string
@@ -132,71 +139,57 @@ func TestNodeString(t *testing.T) {
 		{"Distributed Union with call_type=Local",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Distributed Union",
-				Metadata: &structpb.Struct{
-					Fields: map[string]*structpb.Value{
-						"call_type":             {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
-						"subquery_cluster_node": {Kind: &structpb.Value_StringValue{StringValue: "4"}},
-					},
-				},
+				Metadata: mustNewStruct(map[string]interface{}{
+					"call_type":             "Local",
+					"subquery_cluster_node": "4",
+				}),
 			}}, "Local Distributed Union",
 		},
 		{"Scan with scan_type=IndexScan and Full scan=true",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Scan",
-				Metadata: &structpb.Struct{
-					Fields: map[string]*structpb.Value{
-						"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "IndexScan"}},
-						"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "SongsBySongName"}},
-						"Full scan":   {Kind: &structpb.Value_StringValue{StringValue: "true"}},
-					},
-				},
+				Metadata: mustNewStruct(map[string]interface{}{
+					"scan_type":   "IndexScan",
+					"scan_target": "SongsBySongName",
+					"Full scan":   "true",
+				}),
 			}}, "Index Scan (Full scan: true, Index: SongsBySongName)"},
 		{"Scan with scan_type=TableScan",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Scan",
-				Metadata: &structpb.Struct{
-					Fields: map[string]*structpb.Value{
-						"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "TableScan"}},
-						"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "Songs"}},
-					},
-				},
+				Metadata: mustNewStruct(map[string]interface{}{
+					"scan_type":   "TableScan",
+					"scan_target": "Songs",
+				}),
 			}}, "Table Scan (Table: Songs)"},
 		{"Scan with scan_type=BatchScan",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Scan",
-				Metadata: &structpb.Struct{
-					Fields: map[string]*structpb.Value{
-						"scan_type":   {Kind: &structpb.Value_StringValue{StringValue: "BatchScan"}},
-						"scan_target": {Kind: &structpb.Value_StringValue{StringValue: "$v2"}},
-					},
-				},
+				Metadata: mustNewStruct(map[string]interface{}{
+					"scan_type":   "BatchScan",
+					"scan_target": "$v2",
+				}),
 			}}, "Batch Scan (Batch: $v2)"},
 		{"Sort Limit with call_type=Local",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Sort Limit",
-				Metadata: &structpb.Struct{
-					Fields: map[string]*structpb.Value{
-						"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Local"}},
-					},
-				},
+				Metadata: mustNewStruct(map[string]interface{}{
+					"call_type": "Local",
+				}),
 			}}, "Local Sort Limit"},
 		{"Sort Limit with call_type=Global",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Sort Limit",
-				Metadata: &structpb.Struct{
-					Fields: map[string]*structpb.Value{
-						"call_type": {Kind: &structpb.Value_StringValue{StringValue: "Global"}},
-					},
-				},
+				Metadata: mustNewStruct(map[string]interface{}{
+					"call_type": "Global",
+				}),
 			}}, "Global Sort Limit"},
 		{"Aggregate with iterator_type=Stream",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Aggregate",
-				Metadata: &structpb.Struct{
-					Fields: map[string]*structpb.Value{
-						"iterator_type": {Kind: &structpb.Value_StringValue{StringValue: "Stream"}},
-					},
-				},
+				Metadata: mustNewStruct(map[string]interface{}{
+					"iterator_type": "Stream",
+				}),
 			}}, "Stream Aggregate"},
 	} {
 		if got := test.node.String(); got != test.want {

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -5,18 +5,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genproto/googleapis/spanner/v1"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 )
-
-func protojsonAsStruct(t *testing.T, j string) *structpb.Struct {
-	t.Helper()
-	var result structpb.Struct
-	if err := protojson.Unmarshal([]byte(j), &result); err != nil {
-		t.Fatal("protojsonAsStruct fails, invalid test case", err)
-	}
-	return &result
-}
 
 func mustNewStruct(m map[string]interface{}) *structpb.Struct {
 	if s, err := structpb.NewStruct(m); err != nil {
@@ -25,6 +15,7 @@ func mustNewStruct(m map[string]interface{}) *structpb.Struct {
 		return s
 	}
 }
+
 func TestRenderTreeWithStats(t *testing.T) {
 	for _, test := range []struct {
 		title string
@@ -42,12 +33,11 @@ func TestRenderTreeWithStats(t *testing.T) {
 						},
 						DisplayName: "Distributed Union",
 						Kind:        spanner.PlanNode_RELATIONAL,
-						ExecutionStats: protojsonAsStruct(t, `
-{
-  "latency": {"total": "1", "unit": "msec"},
-  "rows": {"total": "9"},
-  "execution_summary": {"num_executions": "1"}
-}`),
+						ExecutionStats: mustNewStruct(map[string]interface{}{
+							"latency":           map[string]interface{}{"total": "1", "unit": "msec"},
+							"rows":              map[string]interface{}{"total": "9"},
+							"execution_summary": map[string]interface{}{"num_executions": "1"},
+						}),
 					},
 					{
 						Index: 1,
@@ -56,13 +46,12 @@ func TestRenderTreeWithStats(t *testing.T) {
 						},
 						DisplayName: "Distributed Union",
 						Kind:        spanner.PlanNode_RELATIONAL,
-						Metadata:    protojsonAsStruct(t, `{"call_type": "Local"}`),
-						ExecutionStats: protojsonAsStruct(t, `
-{
-  "latency": {"total": "1", "unit": "msec"},
-  "rows": {"total": "9"},
-  "execution_summary": {"num_executions": "1"}
-}`),
+						Metadata:    mustNewStruct(map[string]interface{}{"call_type": "Local"}),
+						ExecutionStats: mustNewStruct(map[string]interface{}{
+							"latency":           map[string]interface{}{"total": "1", "unit": "msec"},
+							"rows":              map[string]interface{}{"total": "9"},
+							"execution_summary": map[string]interface{}{"num_executions": "1"},
+						}),
 					},
 					{
 						Index: 2,
@@ -71,24 +60,22 @@ func TestRenderTreeWithStats(t *testing.T) {
 						},
 						DisplayName: "Serialize Result",
 						Kind:        spanner.PlanNode_RELATIONAL,
-						ExecutionStats: protojsonAsStruct(t, `
-{
-  "latency": {"total": "1", "unit": "msec"},
-  "rows": {"total": "9"},
-  "execution_summary": {"num_executions": "1"}
-}`),
+						ExecutionStats: mustNewStruct(map[string]interface{}{
+							"latency":           map[string]interface{}{"total": "1", "unit": "msec"},
+							"rows":              map[string]interface{}{"total": "9"},
+							"execution_summary": map[string]interface{}{"num_executions": "1"},
+						}),
 					},
 					{
 						Index:       3,
 						DisplayName: "Scan",
 						Kind:        spanner.PlanNode_RELATIONAL,
-						Metadata:    protojsonAsStruct(t, `{"scan_type": "IndexScan", "scan_target": "SongsBySingerAlbumSongNameDesc", "Full scan": "true"}`),
-						ExecutionStats: protojsonAsStruct(t, `
-{
-  "latency": {"total": "1", "unit": "msec"},
-  "rows": {"total": "9"},
-  "execution_summary": {"num_executions": "1"}
-}`),
+						Metadata:    mustNewStruct(map[string]interface{}{"scan_type": "IndexScan", "scan_target": "SongsBySingerAlbumSongNameDesc", "Full scan": "true"}),
+						ExecutionStats: mustNewStruct(map[string]interface{}{
+							"latency":           map[string]interface{}{"total": "1", "unit": "msec"},
+							"rows":              map[string]interface{}{"total": "9"},
+							"execution_summary": map[string]interface{}{"num_executions": "1"},
+						}),
 					},
 				},
 			},


### PR DESCRIPTION
`protobuf-go` v1.25 add native support of well-known types.
It simplify usages of `structpb`.

* `structpb.Struct` supports `MarshalJSON` to implement `json.Marshaller`
  * `pbStruct` wrapper is not needed anymore
* `structpb.NewStruct` simplifies constructing `structpb.Struct`
  * It make test cases simple and Go native