### PR TITLE
Fix layout of EXPLAIN

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -538,17 +538,18 @@ func processPlanWithoutStats(plan *pb.QueryPlan) (rows []Row, predicates []strin
 func processPlanImpl(plan *pb.QueryPlan, withStats bool) (rows []Row, predicates []string) {
 	planNodes := plan.GetPlanNodes()
 	maxWidthOfNodeID := len(fmt.Sprint(getMaxVisibleNodeID(planNodes)))
+	widthOfNodeIDWithIndicator := maxWidthOfNodeID + 1
 
 	tree := BuildQueryPlanTree(plan, 0)
 
 	for _, row := range tree.RenderTreeWithStats(planNodes) {
 		var formattedID string
 		if row.TextOnly {
-			formattedID = strings.Repeat(" ", maxWidthOfNodeID+1)
+			formattedID = strings.Repeat(" ", widthOfNodeIDWithIndicator)
 		} else if len(row.Predicates) > 0 {
-			formattedID = fmt.Sprintf("%*s", maxWidthOfNodeID, "*"+fmt.Sprint(row.ID))
+			formattedID = fmt.Sprintf("%*s", widthOfNodeIDWithIndicator, "*"+fmt.Sprint(row.ID))
 		} else {
-			formattedID = fmt.Sprintf("%*d", maxWidthOfNodeID+1, row.ID)
+			formattedID = fmt.Sprintf("%*d", widthOfNodeIDWithIndicator, row.ID)
 		}
 		if withStats {
 			rows = append(rows, Row{[]string{formattedID, row.Text, row.RowsTotal, row.Execution, row.LatencyTotal}})


### PR DESCRIPTION
The padding of `ID` column in `EXPLAIN` is broken since #73 
Fix it.

## Before

```
+-----+----------------------------------------------------------------------------------------------+
| ID  | Query_Execution_Plan (EXPERIMENTAL)                                                          |
+-----+----------------------------------------------------------------------------------------------+
|     | .                                                                                            |
|   0 | +- Global Limit                                                                              |
| *1  |     +- Distributed Cross Apply                                                               |
|   2 |         +- [Input] Create Batch                                                              |
|   3 |         |   +- Compute Struct                                                                |
|   4 |         |       +- Local Sort Limit                                                          |
|   5 |         |           +- Cross Apply                                                           |
|   6 |         |               +- [Input] Array Unnest                                              |
|  11 |         |               +- [Map] Global Limit                                                |
| *12 |         |                   +- Distributed Union                                             |
|  13 |         |                       +- Local Limit                                               |
|  14 |         |                           +- Local Distributed Union                               |
| *15 |         |                               +- FilterScan                                        |
|  16 |         |                                   +- Index Scan (Index: Order1MShardCreatedAtDesc) |
|  37 |         +- [Map] Serialize Result                                                            |
|  38 |             +- MiniBatchKeyOrder                                                             |
|  39 |                 +- Minor Sort Limit                                                          |
|  40 |                     +- RowCount                                                              |
|  41 |                         +- Cross Apply                                                       |
|  42 |                             +- [Input] RowCount                                              |
|  43 |                             |   +- Local Minor Sort                                          |
|  44 |                             |       +- MiniBatchAssign                                       |
|  45 |                             |           +- Batch Scan (Batch: $v2)                           |
|  56 |                             +- [Map] Local Distributed Union                                 |
| *57 |                                 +- FilterScan                                                |
|  58 |                                     +- Table Scan (Table: Order1M)                           |
+-----+----------------------------------------------------------------------------------------------+
Predicates(identified by ID):
  1: Split Range: ($OrderId_4 = $sort_OrderId)
 12: Split Range: ($ShardCreatedAt = $OneShardCreatedAt)
 15: Seek Condition: ($ShardCreatedAt = $OneShardCreatedAt)
 57: Seek Condition: ($OrderId_4 = $sort_batched_OrderId)

```

## After


```
+-----+----------------------------------------------------------------------------------------------+
| ID  | Query_Execution_Plan (EXPERIMENTAL)                                                          |
+-----+----------------------------------------------------------------------------------------------+
|     | .                                                                                            |
|   0 | +- Global Limit                                                                              |
|  *1 |     +- Distributed Cross Apply                                                               |
|   2 |         +- [Input] Create Batch                                                              |
|   3 |         |   +- Compute Struct                                                                |
|   4 |         |       +- Local Sort Limit                                                          |
|   5 |         |           +- Cross Apply                                                           |
|   6 |         |               +- [Input] Array Unnest                                              |
|  11 |         |               +- [Map] Global Limit                                                |
| *12 |         |                   +- Distributed Union                                             |
|  13 |         |                       +- Local Limit                                               |
|  14 |         |                           +- Local Distributed Union                               |
| *15 |         |                               +- FilterScan                                        |
|  16 |         |                                   +- Index Scan (Index: Order1MShardCreatedAtDesc) |
|  37 |         +- [Map] Serialize Result                                                            |
|  38 |             +- MiniBatchKeyOrder                                                             |
|  39 |                 +- Minor Sort Limit                                                          |
|  40 |                     +- RowCount                                                              |
|  41 |                         +- Cross Apply                                                       |
|  42 |                             +- [Input] RowCount                                              |
|  43 |                             |   +- Local Minor Sort                                          |
|  44 |                             |       +- MiniBatchAssign                                       |
|  45 |                             |           +- Batch Scan (Batch: $v2)                           |
|  56 |                             +- [Map] Local Distributed Union                                 |
| *57 |                                 +- FilterScan                                                |
|  58 |                                     +- Table Scan (Table: Order1M)                           |
+-----+----------------------------------------------------------------------------------------------+
Predicates(identified by ID):
  1: Split Range: ($OrderId_4 = $sort_OrderId)
 12: Split Range: ($ShardCreatedAt = $OneShardCreatedAt)
 15: Seek Condition: ($ShardCreatedAt = $OneShardCreatedAt)
 57: Seek Condition: ($OrderId_4 = $sort_batched_OrderId)
```