### PR TITLE
Fix maxVisibleNodeID could be random result

### DIFF
--- a/query_plan.go
+++ b/query_plan.go
@@ -249,13 +249,14 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 	}
 }
 
-func getMaxVisibleNodeID(planNodes []*pb.PlanNode) int32 {
+func getMaxVisibleNodeID(plan *pb.QueryPlan) int32 {
 	var maxVisibleNodeID int32
-	for _, planNode := range planNodes {
+	// We assume that plan_nodes[] is pre-sorted in ascending order.
+	// See QueryPlan.plan_nodes[] in the document.
+	// https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1?hl=en#google.spanner.v1.QueryPlan.FIELDS.repeated.google.spanner.v1.PlanNode.google.spanner.v1.QueryPlan.plan_nodes
+	for _, planNode := range plan.GetPlanNodes() {
 		if (&Node{PlanNode: planNode}).IsVisible() {
-			if planNode.Index > maxVisibleNodeID {
-				maxVisibleNodeID = planNode.Index
-			}
+			maxVisibleNodeID = planNode.Index
 		}
 	}
 	return maxVisibleNodeID

--- a/query_plan.go
+++ b/query_plan.go
@@ -253,7 +253,9 @@ func getMaxVisibleNodeID(planNodes []*pb.PlanNode) int32 {
 	var maxVisibleNodeID int32
 	for _, planNode := range planNodes {
 		if (&Node{PlanNode: planNode}).IsVisible() {
-			maxVisibleNodeID = planNode.Index
+			if planNode.Index > maxVisibleNodeID {
+				maxVisibleNodeID = planNode.Index
+			}
 		}
 	}
 	return maxVisibleNodeID

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -190,26 +190,18 @@ func TestNodeString(t *testing.T) {
 func TestGetMaxVisibleNodeID(t *testing.T) {
 	for _, tt := range []struct {
 		desc  string
-		input []*pb.PlanNode
+		input *pb.QueryPlan
 		want  int32
 	}{
 		{
-			desc: "ascending order",
-			input: []*pb.PlanNode{
-				&pb.PlanNode{Index: 1, DisplayName: "Index Scan"},
-				&pb.PlanNode{Index: 999, DisplayName: "Constant"}, // This is not visible
-				&pb.PlanNode{Index: 2, DisplayName: "Index Scan"},
-				&pb.PlanNode{Index: 3, DisplayName: "Index Scan"},
-			},
-			want: 3,
-		},
-		{
-			desc: "random order",
-			input: []*pb.PlanNode{
-				&pb.PlanNode{Index: 1, DisplayName: "Index Scan"},
-				&pb.PlanNode{Index: 3, DisplayName: "Index Scan"},
-				&pb.PlanNode{Index: 999, DisplayName: "Constant"}, // This is not visible
-				&pb.PlanNode{Index: 2, DisplayName: "Index Scan"},
+			desc: "pr-sorted order",
+			input: &pb.QueryPlan{
+				PlanNodes: []*pb.PlanNode{
+					{Index: 1, DisplayName: "Index Scan"},
+					{Index: 2, DisplayName: "Index Scan"},
+					{Index: 3, DisplayName: "Index Scan"},
+					{Index: 4, DisplayName: "Constant"}, // This is not visible
+				},
 			},
 			want: 3,
 		},

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -194,7 +194,7 @@ func TestGetMaxVisibleNodeID(t *testing.T) {
 		want  int32
 	}{
 		{
-			desc: "pr-sorted order",
+			desc: "pre-sorted order",
 			input: &pb.QueryPlan{
 				PlanNodes: []*pb.PlanNode{
 					{Index: 1, DisplayName: "Index Scan"},

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genproto/googleapis/spanner/v1"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	pb "google.golang.org/genproto/googleapis/spanner/v1"
 )
 
 func mustNewStruct(m map[string]interface{}) *structpb.Struct {
@@ -181,6 +183,39 @@ func TestNodeString(t *testing.T) {
 	} {
 		if got := test.node.String(); got != test.want {
 			t.Errorf("%s: node.String() = %q but want %q", test.title, got, test.want)
+		}
+	}
+}
+
+func TestGetMaxVisibleNodeID(t *testing.T) {
+	for _, tt := range []struct {
+		desc  string
+		input []*pb.PlanNode
+		want  int32
+	}{
+		{
+			desc: "ascending order",
+			input: []*pb.PlanNode{
+				&pb.PlanNode{Index: 1, DisplayName: "Index Scan"},
+				&pb.PlanNode{Index: 999, DisplayName: "Constant"}, // This is not visible
+				&pb.PlanNode{Index: 2, DisplayName: "Index Scan"},
+				&pb.PlanNode{Index: 3, DisplayName: "Index Scan"},
+			},
+			want: 3,
+		},
+		{
+			desc: "random order",
+			input: []*pb.PlanNode{
+				&pb.PlanNode{Index: 1, DisplayName: "Index Scan"},
+				&pb.PlanNode{Index: 3, DisplayName: "Index Scan"},
+				&pb.PlanNode{Index: 999, DisplayName: "Constant"}, // This is not visible
+				&pb.PlanNode{Index: 2, DisplayName: "Index Scan"},
+			},
+			want: 3,
+		},
+	} {
+		if got := getMaxVisibleNodeID(tt.input); got != tt.want {
+			t.Errorf("getMaxVisibleNodeID(%s) = %d, but want = %d", tt.input, got, tt.want)
 		}
 	}
 }

--- a/statement.go
+++ b/statement.go
@@ -537,7 +537,7 @@ func processPlanWithoutStats(plan *pb.QueryPlan) (rows []Row, predicates []strin
 
 func processPlanImpl(plan *pb.QueryPlan, withStats bool) (rows []Row, predicates []string) {
 	planNodes := plan.GetPlanNodes()
-	maxWidthOfNodeID := len(fmt.Sprint(getMaxVisibleNodeID(planNodes)))
+	maxWidthOfNodeID := len(fmt.Sprint(getMaxVisibleNodeID(plan)))
 	widthOfNodeIDWithIndicator := maxWidthOfNodeID + 1
 
 	tree := BuildQueryPlanTree(plan, 0)


### PR DESCRIPTION
It is not guaranteed that `*pb.QueryPlan.GetPlanNodes()` returns the PlanNode in ascending order, so we need to compare the planNode.Index to get the max id.

Otherwise the ID column shows invalid spaces like this,
```
+------+
| ID   |
+------+
|  *7  |
| *79  |
|   80 |
...
```