### PR TITLE
Remove dummy root for query execution plan

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/mattn/go-runewidth v0.0.8 // indirect
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/xlab/treeprint v1.0.0
+	github.com/xlab/treeprint v1.0.1-0.20200715141336-10e0bc383e01
 	google.golang.org/api v0.21.0
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.28.1

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/xlab/treeprint v1.0.0 h1:J0TkWtiuYgtdlrkkrDLISYBQ92M+X5m4LrIIMKrbDTs=
 github.com/xlab/treeprint v1.0.0/go.mod h1:IoImgRak9i3zJyuxOKUP1v4UZd1tMoKkq/Cimt1uhCg=
+github.com/xlab/treeprint v1.0.1-0.20200715141336-10e0bc383e01 h1:uk2OUothYXw3JM+BEogrZA9AJ8g6ti77HjdAcTu3Gz8=
+github.com/xlab/treeprint v1.0.1-0.20200715141336-10e0bc383e01/go.mod h1:IoImgRak9i3zJyuxOKUP1v4UZd1tMoKkq/Cimt1uhCg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -82,41 +82,46 @@ func TestRenderTreeWithStats(t *testing.T) {
 				},
 			},
 			want: []QueryPlanRow{
-				{Text: ".", TextOnly: true},
 				{
 					ID:           0,
-					Text:         "+- Distributed Union",
+					Text:         "Distributed Union",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
 				{
 					ID:           1,
-					Text:         "    +- Local Distributed Union",
+					Text:         "+- Local Distributed Union",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
 				{
 					ID:           2,
-					Text:         "        +- Serialize Result",
+					Text:         "    +- Serialize Result",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
 				{
 					ID:           3,
-					Text:         "            +- Index Scan (Full scan: true, Index: SongsBySingerAlbumSongNameDesc)",
+					Text:         "        +- Index Scan (Full scan: true, Index: SongsBySingerAlbumSongNameDesc)",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
 			}},
 	} {
-		tree := BuildQueryPlanTree(test.plan, 0)
-		if got := tree.RenderTreeWithStats(test.plan.GetPlanNodes()); !cmp.Equal(test.want, got) {
-			t.Errorf("%s: node.RenderTreeWithStats() differ: %s", test.title, cmp.Diff(test.want, got))
-		}
+		t.Run(test.title, func(t *testing.T) {
+			tree := BuildQueryPlanTree(test.plan, 0)
+			got, err := tree.RenderTreeWithStats(test.plan.GetPlanNodes())
+			if err != nil {
+				t.Errorf("error should be nil, but got = %v", err)
+			}
+			if !cmp.Equal(test.want, got) {
+				t.Errorf("node.RenderTreeWithStats() differ: %s", cmp.Diff(test.want, got))
+			}
+		})
 	}
 }
 func TestNodeString(t *testing.T) {


### PR DESCRIPTION
## Summary

Current query plan shows a dummy root row (`.`) which is rendered by treeprint. This root row is not needed and it's better to treat the first query execution operator as a root row.

This Pull Request has also the following changes.

* Remove `QueryPlanRow.TextOnly` field as the dummy root is removed
* Handle error properly which could happen in building the query execution plan tree.

## Before

```
$ spanner-cli -e 'EXPLAIN ANALYZE SELECT s.SongName, s.Duration FROM Songs@{force_index=SongsBySongName} AS s WHERE STARTS_WITH(s.SongName, "B");' -t
+-----+----------------------------------------------------------------+---------------+------------+---------------+                                                                      
| ID  | Query_Execution_Plan                                           | Rows_Returned | Executions | Total_Latency |
+-----+----------------------------------------------------------------+---------------+------------+---------------+                                                                                                                                                                                        
|     | .                                                              |               |            |               |
|  *0 | +- Distributed Union                                           | 1             | 1          | 0.25 msecs    |
|  *1 |     +- Distributed Cross Apply                                 | 1             | 1          | 0.2 msecs     |
|   2 |         +- [Input] Create Batch                                |               |            |               |                                                                    
|   3 |         |   +- Local Distributed Union                         | 1             | 1          | 0.11 msecs    |                                                                                      
|   4 |         |       +- Compute Struct                              | 1             | 1          | 0.1 msecs     |
|  *5 |         |           +- FilterScan                              | 1             | 1          | 0.1 msecs     |           
|   6 |         |               +- Index Scan (Index: SongsBySongName) | 1             | 1          | 0.09 msecs    |
|  20 |         +- [Map] Serialize Result                              | 1             | 1          | 0.06 msecs    |                          
|  21 |             +- Cross Apply                                     | 1             | 1          | 0.05 msecs    |                                                                                                                                                                                        
|  22 |                 +- [Input] Batch Scan (Batch: $v2)             | 1             | 1          | 0 msecs       |                                                                    
|  27 |                 +- [Map] Local Distributed Union               | 1             | 1          | 0.05 msecs    |                                                                                      
| *28 |                     +- FilterScan                              | 1             | 1          | 0.04 msecs    |                                                                    
|  29 |                         +- Table Scan (Table: Songs)           | 1             | 1          | 0.04 msecs    |
+-----+----------------------------------------------------------------+---------------+------------+---------------+
```

## After

```
$ spanner-cli -e 'EXPLAIN ANALYZE SELECT s.SongName, s.Duration FROM Songs@{force_index=SongsBySongName} AS s WHERE STARTS_WITH(s.SongName, "B");' -t
+-----+------------------------------------------------------------+---------------+------------+---------------+    
| ID  | Query_Execution_Plan                                       | Rows_Returned | Executions | Total_Latency |                                                                                                                                                                                            
+-----+------------------------------------------------------------+---------------+------------+---------------+    
|  *0 | Distributed Union                                          | 1             | 1          | 0.19 msecs    |    
|  *1 | +- Distributed Cross Apply                                 | 1             | 1          | 0.17 msecs    |                                                                        
|   2 |     +- [Input] Create Batch                                |               |            |               |                                                                                          
|   3 |     |   +- Local Distributed Union                         | 1             | 1          | 0.09 msecs    |    
|   4 |     |       +- Compute Struct                              | 1             | 1          | 0.08 msecs    |    
|  *5 |     |           +- FilterScan                              | 1             | 1          | 0.08 msecs    |                              
|   6 |     |               +- Index Scan (Index: SongsBySongName) | 1             | 1          | 0.08 msecs    |                                                                                                                                                                                            
|  20 |     +- [Map] Serialize Result                              | 1             | 1          | 0.04 msecs    |
|  21 |         +- Cross Apply                                     | 1             | 1          | 0.04 msecs    |
|  22 |             +- [Input] Batch Scan (Batch: $v2)             | 1             | 1          | 0 msecs       |
|  27 |             +- [Map] Local Distributed Union               | 1             | 1          | 0.03 msecs    |
| *28 |                 +- FilterScan                              | 1             | 1          | 0.03 msecs    |
|  29 |                     +- Table Scan (Table: Songs)           | 1             | 1          | 0.03 msecs    |
+-----+------------------------------------------------------------+---------------+------------+---------------+
```