### PR TITLE
Change query plan indent size

### DIFF
--- a/query_plan.go
+++ b/query_plan.go
@@ -32,6 +32,8 @@ func init() {
 	treeprint.EdgeTypeLink = "|"
 	treeprint.EdgeTypeMid = "+-"
 	treeprint.EdgeTypeEnd = "+-"
+
+	treeprint.IndentSize = 2
 }
 
 type Link struct {

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -98,14 +98,14 @@ func TestRenderTreeWithStats(t *testing.T) {
 				},
 				{
 					ID:           2,
-					Text:         "    +- Serialize Result",
+					Text:         "   +- Serialize Result",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
 				{
 					ID:           3,
-					Text:         "        +- Index Scan (Full scan: true, Index: SongsBySingerAlbumSongNameDesc)",
+					Text:         "      +- Index Scan (Full scan: true, Index: SongsBySingerAlbumSongNameDesc)",
 					RowsTotal:    "9",
 					Execution:    "1",
 					LatencyTotal: "1 msec",


### PR DESCRIPTION
## Summary

I changed the query plan indent size from 3 (default of treeprint) to 2. This is due to the following reasons.

* It looks better to align the branch character (`+`) with the first character of the operator name in the previous level.
* It shortens the width of the result, yet it is still readable.

## Before

```
$ spanner-cli -e 'EXPLAIN ANALYZE SELECT s.SongName, s.Duration FROM Songs@{force_index=SongsBySongName} AS s WHERE STARTS_WITH(s.SongName, "B");' -t
+-----+----------------------------------------------------------------+---------------+------------+---------------+                                                                      
| ID  | Query_Execution_Plan                                           | Rows_Returned | Executions | Total_Latency |
+-----+----------------------------------------------------------------+---------------+------------+---------------+                                                                                                                                                                                        
|     | .                                                              |               |            |               |
|  *0 | +- Distributed Union                                           | 1             | 1          | 0.25 msecs    |
|  *1 |     +- Distributed Cross Apply                                 | 1             | 1          | 0.2 msecs     |
|   2 |         +- [Input] Create Batch                                |               |            |               |                                                                    
|   3 |         |   +- Local Distributed Union                         | 1             | 1          | 0.11 msecs    |                                                                                      
|   4 |         |       +- Compute Struct                              | 1             | 1          | 0.1 msecs     |
|  *5 |         |           +- FilterScan                              | 1             | 1          | 0.1 msecs     |           
|   6 |         |               +- Index Scan (Index: SongsBySongName) | 1             | 1          | 0.09 msecs    |
|  20 |         +- [Map] Serialize Result                              | 1             | 1          | 0.06 msecs    |                          
|  21 |             +- Cross Apply                                     | 1             | 1          | 0.05 msecs    |                                                                                                                                                                                        
|  22 |                 +- [Input] Batch Scan (Batch: $v2)             | 1             | 1          | 0 msecs       |                                                                    
|  27 |                 +- [Map] Local Distributed Union               | 1             | 1          | 0.05 msecs    |                                                                                      
| *28 |                     +- FilterScan                              | 1             | 1          | 0.04 msecs    |                                                                    
|  29 |                         +- Table Scan (Table: Songs)           | 1             | 1          | 0.04 msecs    |
+-----+----------------------------------------------------------------+---------------+------------+---------------+
```

## After
```
$ spanner-cli -e 'EXPLAIN ANALYZE SELECT s.SongName, s.Duration FROM Songs@{force_index=SongsBySongName} AS s WHERE STARTS_WITH(s.SongName, "B");' -t
+-----+-------------------------------------------------------+---------------+------------+---------------+
| ID  | Query_Execution_Plan                                  | Rows_Returned | Executions | Total_Latency |
+-----+-------------------------------------------------------+---------------+------------+---------------+
|  *0 | Distributed Union                                     | 1             | 1          | 3 msecs       |
|  *1 | +- Distributed Cross Apply                            | 1             | 1          | 2.98 msecs    |
|   2 |    +- [Input] Create Batch                            |               |            |               |
|   3 |    |  +- Local Distributed Union                      | 1             | 1          | 2.8 msecs     |
|   4 |    |     +- Compute Struct                            | 1             | 1          | 2.79 msecs    |
|  *5 |    |        +- FilterScan                             | 1             | 1          | 2.79 msecs    |
|   6 |    |           +- Index Scan (Index: SongsBySongName) | 1             | 1          | 2.79 msecs    |
|  20 |    +- [Map] Serialize Result                          | 1             | 1          | 0.12 msecs    |
|  21 |       +- Cross Apply                                  | 1             | 1          | 0.12 msecs    |
|  22 |          +- [Input] Batch Scan (Batch: $v2)           | 1             | 1          | 0 msecs       |
|  27 |          +- [Map] Local Distributed Union             | 1             | 1          | 0.11 msecs    |
| *28 |             +- FilterScan                             | 1             | 1          | 0.1 msecs     |
|  29 |                +- Table Scan (Table: Songs)           | 1             | 1          | 0.1 msecs     |
+-----+-------------------------------------------------------+---------------+------------+---------------+
```