### PR TITLE
Always show result line with -v option even in batch mode

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -377,7 +377,8 @@ func printResult(out io.Writer, result *Result, mode DisplayMode, interactive, v
 		}
 		fmt.Fprintln(out)
 	}
-	if result.ForceVerbose {
+
+	if verbose || result.ForceVerbose {
 		fmt.Fprint(out, resultLine(result, true))
 	} else if interactive {
 		fmt.Fprint(out, resultLine(result, verbose))


### PR DESCRIPTION
close https://github.com/cloudspannerecosystem/spanner-cli/issues/80.

## Examples

### UPDATE statement

```
$ spanner-cli -p test -i test -d test -e "UPDATE Singers SET FirstName = 'Catalina2' WHERE SingerId = 2;"
$ spanner-cli -p test -i test -d test -e "UPDATE Singers SET FirstName = 'Catalina2' WHERE SingerId = 2;" -v
Query OK, 1 rows affected ()
timestamp: 2020-08-07T14:52:59.522765+09:00
```

### SELECT statement
```
$ spanner-cli -p test -i test -d test -e "SELECT * FROM Singers LIMIT 3;" 
SingerId        FirstName       LastName        SingerInfo      BirthDate
4       Lea     Martin  NULL    1991-11-09
2       Catalina2       Smith   NULL    1990-08-17
1       Marc    Richards        NULL    1970-09-03
$ spanner-cli -p test -i test -d test -e "SELECT * FROM Singers LIMIT 3;" -v
SingerId        FirstName       LastName        SingerInfo      BirthDate
4       Lea     Martin  NULL    1991-11-09
2       Catalina2       Smith   NULL    1990-08-17
1       Marc    Richards        NULL    1970-09-03
3 rows in set (266.004us)
timestamp: 2020-08-07T14:53:22.455269+09:00
```