### PR TITLE
Hide Parameter node

### DIFF
--- a/query_plan.go
+++ b/query_plan.go
@@ -163,7 +163,7 @@ func (n *Node) RenderTreeWithStats(planNodes []*pb.PlanNode) ([]QueryPlanRow, er
 
 func (n *Node) IsVisible() bool {
 	operator := n.PlanNode.DisplayName
-	if operator == "Function" || operator == "Reference" || operator == "Constant" || operator == "Array Constructor" {
+	if operator == "Function" || operator == "Reference" || operator == "Constant" || operator == "Array Constructor" || operator == "Parameter" {
 		return false
 	}
 


### PR DESCRIPTION
The operator node named `Parameter` is shown but it is better to be hidden like `Function` and `Reference` etc.

## Before

```
> EXPLAIN SELECT * FROM Singers WHERE SingerId = @singer_id;
+-----+----------------------------------------------------+
| ID  | Query_Execution_Plan (EXPERIMENTAL)                |
+-----+----------------------------------------------------+
|  *0 | Distributed Union                                  |
|   1 | +- Local Distributed Union                         |
|   2 |    +- Serialize Result                             |
|  *3 |       +- FilterScan                                |
|   4 |       |  +- Table Scan (Table: Singers)            |
|  14 |       +- Parameter (name: singer_id, type: scalar) |
+-----+----------------------------------------------------+
Predicates(identified by ID):
  0: Split Range: ($SingerId = @singer_id)
  3: Seek Condition: ($SingerId = @singer_id)

1 rows in set (0.30 sec)
```

## After

```
> EXPLAIN SELECT * FROM Singers WHERE SingerId = @singer_id;
+----+-----------------------------------------+
| ID | Query_Execution_Plan (EXPERIMENTAL)     |
+----+-----------------------------------------+
| *0 | Distributed Union                       |
|  1 | +- Local Distributed Union              |
|  2 |    +- Serialize Result                  |
| *3 |       +- FilterScan                     |
|  4 |          +- Table Scan (Table: Singers) |
+----+-----------------------------------------+
Predicates(identified by ID):
 0: Split Range: ($SingerId = @singer_id)
 3: Seek Condition: ($SingerId = @singer_id)

1 rows in set (0.34 sec)
```