### PR TITLE
Suppress to show duplicated subtrees of scalar subqueries

### DIFF
--- a/query_plan.go
+++ b/query_plan.go
@@ -270,7 +270,12 @@ func renderTreeWithStats(tree treeprint.Tree, linkType string, node *Node) {
 		} else {
 			branch = tree.AddBranch(str)
 		}
-		for _, child := range node.Children {
+		for i, child := range node.Children {
+			// Serialize Result with scalar subqueries can have duplicate children
+			// so process only the first child and children have Scalar type.
+			if node.PlanNode.DisplayName == "Serialize Result" && !(i == 0 || child.Type == "Scalar") {
+				continue
+			}
 			renderTreeWithStats(branch, child.Type, child.Dest)
 		}
 	} else {

--- a/testdata/plans/array_subqueries.input.json
+++ b/testdata/plans/array_subqueries.input.json
@@ -1,0 +1,287 @@
+{
+  "planNodes": [
+    {
+      "childLinks": [
+        {
+          "childIndex": 1
+        },
+        {
+          "childIndex": 22,
+          "type": "Split Range"
+        }
+      ],
+      "displayName": "Distributed Union",
+      "kind": "RELATIONAL",
+      "metadata": {
+        "subquery_cluster_node": "1"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 2
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 1,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Local",
+        "subquery_cluster_node": "2"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 3
+        },
+        {
+          "childIndex": 6
+        },
+        {
+          "childIndex": 7
+        },
+        {
+          "childIndex": 7,
+          "type": "Scalar"
+        }
+      ],
+      "displayName": "Serialize Result",
+      "index": 2,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 4,
+          "variable": "AlbumId"
+        },
+        {
+          "childIndex": 5,
+          "variable": "SingerId"
+        }
+      ],
+      "displayName": "Scan",
+      "index": 3,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "Full scan": "true",
+        "scan_target": "AlbumsByAlbumTitle",
+        "scan_type": "IndexScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 4,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "AlbumId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 5,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SingerId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 6,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$AlbumId"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 8
+        },
+        {
+          "childIndex": 21
+        }
+      ],
+      "displayName": "Array Subquery",
+      "index": 7,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$sv_1"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 9
+        },
+        {
+          "childIndex": 18,
+          "type": "Split Range"
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 8,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "subquery_cluster_node": "9"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 10
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 9,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Local",
+        "subquery_cluster_node": "10"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 11
+        },
+        {
+          "childIndex": 17,
+          "type": "Seek Condition"
+        }
+      ],
+      "displayName": "FilterScan",
+      "index": 10,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 12,
+          "variable": "ConcertDate"
+        },
+        {
+          "childIndex": 13,
+          "variable": "SingerId_1"
+        }
+      ],
+      "displayName": "Scan",
+      "index": 11,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "scan_target": "ConcertsBySingerId",
+        "scan_type": "IndexScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 12,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "ConcertDate"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 13,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SingerId"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 15
+        },
+        {
+          "childIndex": 16
+        }
+      ],
+      "displayName": "Function",
+      "index": 14,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($SingerId_1 = $SingerId)"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 15,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId_1"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 16,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 14
+        }
+      ],
+      "displayName": "Function",
+      "index": 17,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($SingerId_1 = $SingerId)"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 19
+        },
+        {
+          "childIndex": 20
+        }
+      ],
+      "displayName": "Function",
+      "index": 18,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($SingerId_1 = $SingerId)"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 19,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId_1"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 20,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 21,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$ConcertDate"
+      }
+    },
+    {
+      "displayName": "Constant",
+      "index": 22,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "true"
+      }
+    }
+  ]
+}

--- a/testdata/plans/scalar_subqueries.input.json
+++ b/testdata/plans/scalar_subqueries.input.json
@@ -1,0 +1,371 @@
+{
+  "planNodes": [
+    {
+      "childLinks": [
+        {
+          "childIndex": 1
+        },
+        {
+          "childIndex": 28,
+          "type": "Split Range"
+        }
+      ],
+      "displayName": "Distributed Union",
+      "kind": "RELATIONAL",
+      "metadata": {
+        "subquery_cluster_node": "1"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 2
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 1,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Local",
+        "subquery_cluster_node": "2"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 3
+        },
+        {
+          "childIndex": 5
+        },
+        {
+          "childIndex": 6
+        },
+        {
+          "childIndex": 10,
+          "type": "Scalar"
+        }
+      ],
+      "displayName": "Serialize Result",
+      "index": 2,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 4,
+          "variable": "FirstName"
+        }
+      ],
+      "displayName": "Scan",
+      "index": 3,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "Full scan": "true",
+        "scan_target": "SingersByFirstLastName",
+        "scan_type": "IndexScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 4,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "FirstName"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 5,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$FirstName"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 7
+        },
+        {
+          "childIndex": 10
+        },
+        {
+          "childIndex": 27
+        }
+      ],
+      "displayName": "Function",
+      "index": 6,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "IF(($FirstName = 'Alice'), $sv_1, 0)",
+        "subqueries": {
+          "$sv_1": 10
+        }
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 8
+        },
+        {
+          "childIndex": 9
+        }
+      ],
+      "displayName": "Function",
+      "index": 7,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($FirstName = 'Alice')"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 8,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$FirstName"
+      }
+    },
+    {
+      "displayName": "Constant",
+      "index": 9,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "'Alice'"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 11
+        },
+        {
+          "childIndex": 26
+        }
+      ],
+      "displayName": "Scalar Subquery",
+      "index": 10,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$sv_1"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 12
+        },
+        {
+          "childIndex": 24,
+          "type": "Agg",
+          "variable": "agg1"
+        }
+      ],
+      "displayName": "Aggregate",
+      "index": 11,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Global",
+        "iterator_type": "Stream",
+        "scalar_aggregate": "true"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 13
+        },
+        {
+          "childIndex": 23,
+          "type": "Split Range"
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 12,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "subquery_cluster_node": "13"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 14
+        },
+        {
+          "childIndex": 22,
+          "type": "Agg",
+          "variable": "v1"
+        }
+      ],
+      "displayName": "Aggregate",
+      "index": 13,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Local",
+        "iterator_type": "Stream",
+        "scalar_aggregate": "true"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 15
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 14,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Local",
+        "subquery_cluster_node": "15"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 16
+        },
+        {
+          "childIndex": 21,
+          "type": "Residual Condition"
+        }
+      ],
+      "displayName": "FilterScan",
+      "index": 15,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 17,
+          "variable": "Duration"
+        }
+      ],
+      "displayName": "Scan",
+      "index": 16,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "Full scan": "true",
+        "scan_target": "Songs",
+        "scan_type": "TableScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 17,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "Duration"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 19
+        },
+        {
+          "childIndex": 20
+        }
+      ],
+      "displayName": "Function",
+      "index": 18,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($Duration > 300)"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 19,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$Duration"
+      }
+    },
+    {
+      "displayName": "Constant",
+      "index": 20,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "300"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 18
+        }
+      ],
+      "displayName": "Function",
+      "index": 21,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($Duration > 300)"
+      }
+    },
+    {
+      "displayName": "Function",
+      "index": 22,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "COUNT()"
+      }
+    },
+    {
+      "displayName": "Constant",
+      "index": 23,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "true"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 25
+        }
+      ],
+      "displayName": "Function",
+      "index": 24,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "COUNT_FINAL($v1)"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 25,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$v1"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 26,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$agg1"
+      }
+    },
+    {
+      "displayName": "Constant",
+      "index": 27,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "0"
+      }
+    },
+    {
+      "displayName": "Constant",
+      "index": 28,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR fixes the bug which shows duplicated subtrees when the plan have scalar subqueries.

### Before

```sql
SELECT a.AlbumId,
ARRAY(SELECT ConcertDate
      FROM Concerts
      WHERE Concerts.SingerId = a.SingerId)
FROM Albums AS a;
```
```
+-----+--------------------------------------------------------------------+
| ID  | Query_Execution_Plan (EXPERIMENTAL)                                |
+-----+--------------------------------------------------------------------+
|   0 | Distributed Union                                                  |
|   1 | +- Local Distributed Union                                         |
|   2 |    +- Serialize Result                                             |
|   3 |       +- Index Scan (Full scan: true, Index: AlbumsByAlbumTitle)   |
|   7 |       +- Array Subquery                                            |
|  *8 |       |  +- Distributed Union                                      |
|   9 |       |     +- Local Distributed Union                             |
| *10 |       |        +- FilterScan                                       |
|  11 |       |           +- Table Scan (Full scan: true, Table: Concerts) |
|   7 |       +- [Scalar] Array Subquery                                   |
|  *8 |          +- Distributed Union                                      |
|   9 |             +- Local Distributed Union                             |
| *10 |                +- FilterScan                                       |
|  11 |                   +- Table Scan (Full scan: true, Table: Concerts) |
+-----+--------------------------------------------------------------------+
Predicates(identified by ID):
  8: Split Range: ($SingerId_1 = $SingerId)
 10: Residual Condition: ($SingerId_1 = $SingerId)
  8: Split Range: ($SingerId_1 = $SingerId)
 10: Residual Condition: ($SingerId_1 = $SingerId)
```
### After
```
+-----+------------------------------------------------------------------+
| ID  | Query_Execution_Plan (EXPERIMENTAL)                              |
+-----+------------------------------------------------------------------+
|   0 | Distributed Union                                                |
|   1 | +- Local Distributed Union                                       |
|   2 |    +- Serialize Result                                           |
|   3 |       +- Index Scan (Full scan: true, Index: AlbumsByAlbumTitle) |
|   7 |       +- [Scalar] Array Subquery                                 |
|  *8 |          +- Distributed Union                                    |
|   9 |             +- Local Distributed Union                           |
| *10 |                +- FilterScan                                     |
|  11 |                   +- Index Scan (Index: ConcertsBySingerId)      |
+-----+------------------------------------------------------------------+
Predicates(identified by ID):
  8: Split Range: ($SingerId_1 = $SingerId)
 10: Seek Condition: ($SingerId_1 = $SingerId)
```

fix #89 