### PR TITLE
Improve subquery handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cloud.google.com/go v0.65.0
 	cloud.google.com/go/spanner v1.10.0
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
-	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.2
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/mattn/go-runewidth v0.0.8 // indirect

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -494,7 +494,7 @@ func TestNodeString(t *testing.T) {
 	}
 }
 
-func TestGetMaxVisibleNodeID(t *testing.T) {
+func TestGetMaxRelationalNodeID(t *testing.T) {
 	for _, tt := range []struct {
 		desc  string
 		input *pb.QueryPlan

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -220,6 +220,83 @@ func TestRenderTreeUsingTestdataPlans(t *testing.T) {
 					Text: "                        +- Table Scan (Full scan: true, Table: Songs)",
 				},
 			}},
+		{
+			/*
+				SELECT si.*,
+				  ARRAY(SELECT AS STRUCT a.*,
+				        ARRAY(SELECT AS STRUCT so.*
+				              FROM Songs so
+				              WHERE a.SingerId = so.SingerId AND a.AlbumId = so.AlbumId)
+				        FROM Albums a
+				        WHERE a.SingerId = si.SingerId)
+				FROM Singers si;
+			*/
+			title: "Array Subquery with Compute Struct",
+			file:  "testdata/plans/array_subqueries_with_compute_struct.input.json",
+			want: []QueryPlanRow{
+				{
+					Text: "Distributed Union",
+				},
+				{
+					ID:   1,
+					Text: "+- Local Distributed Union",
+				},
+				{
+					ID:   2,
+					Text: "   +- Serialize Result",
+				},
+				{
+					ID:   3,
+					Text: "      +- Table Scan (Full scan: true, Table: Singers)",
+				},
+				{
+					ID:   14,
+					Text: "      +- [Scalar] Array Subquery",
+				},
+				{
+					ID:   15,
+					Text: "         +- Local Distributed Union",
+				},
+				{
+					ID:   16,
+					Text: "            +- Compute Struct",
+				},
+				{
+					ID:   17,
+					Text: "               +- FilterScan",
+					Predicates: []string{
+						"Seek Condition: ($SingerId_1 = $SingerId)",
+					},
+				},
+				{
+					ID:   18,
+					Text: "               |  +- Table Scan (Table: Albums)",
+				},
+				{
+					ID:   31,
+					Text: "               +- [Scalar] Array Subquery",
+				},
+				{
+					ID:   32,
+					Text: "                  +- Local Distributed Union",
+				},
+				{
+					ID:   33,
+					Text: "                     +- Compute Struct",
+				},
+				{
+					ID:   34,
+					Text: "                        +- FilterScan",
+					Predicates: []string{
+						"Seek Condition: (($SingerId_2 = $SingerId_1) AND ($AlbumId_1 = $AlbumId))",
+					},
+				},
+				{
+					ID:   35,
+					Text: "                           +- Table Scan (Table: Songs)",
+				},
+			},
+		},
 	} {
 		t.Run(test.title, func(t *testing.T) {
 			b, err := ioutil.ReadFile(test.file)
@@ -427,17 +504,18 @@ func TestGetMaxVisibleNodeID(t *testing.T) {
 			desc: "pre-sorted order",
 			input: &pb.QueryPlan{
 				PlanNodes: []*pb.PlanNode{
-					{Index: 1, DisplayName: "Index Scan"},
-					{Index: 2, DisplayName: "Index Scan"},
-					{Index: 3, DisplayName: "Index Scan"},
-					{Index: 4, DisplayName: "Constant"}, // This is not visible
+					{Index: 0, DisplayName: "Scalar Subquery", Kind: pb.PlanNode_SCALAR},
+					{Index: 1, DisplayName: "Index Scan", Kind: pb.PlanNode_RELATIONAL},
+					{Index: 2, DisplayName: "Index Scan", Kind: pb.PlanNode_RELATIONAL},
+					{Index: 3, DisplayName: "Index Scan", Kind: pb.PlanNode_RELATIONAL},
+					{Index: 4, DisplayName: "Constant", Kind: pb.PlanNode_SCALAR}, // This is not visible
 				},
 			},
 			want: 3,
 		},
 	} {
-		if got := getMaxVisibleNodeID(tt.input); got != tt.want {
-			t.Errorf("getMaxVisibleNodeID(%s) = %d, but want = %d", tt.input, got, tt.want)
+		if got := getMaxRelationalNodeID(tt.input); got != tt.want {
+			t.Errorf("getMaxRelationalNodeID(%s) = %d, but want = %d", tt.input, got, tt.want)
 		}
 	}
 }

--- a/statement.go
+++ b/statement.go
@@ -551,7 +551,7 @@ func processPlanWithoutStats(plan *pb.QueryPlan) (rows []Row, predicates []strin
 
 func processPlanImpl(plan *pb.QueryPlan, withStats bool) (rows []Row, predicates []string, err error) {
 	planNodes := plan.GetPlanNodes()
-	maxWidthOfNodeID := len(fmt.Sprint(getMaxVisibleNodeID(plan)))
+	maxWidthOfNodeID := len(fmt.Sprint(getMaxRelationalNodeID(plan)))
 	widthOfNodeIDWithIndicator := maxWidthOfNodeID + 1
 
 	tree := BuildQueryPlanTree(plan, 0)

--- a/testdata/plans/array_subqueries_with_compute_struct.input.json
+++ b/testdata/plans/array_subqueries_with_compute_struct.input.json
@@ -1,0 +1,718 @@
+{
+  "planNodes": [
+    {
+      "childLinks": [
+        {
+          "childIndex": 1
+        },
+        {
+          "childIndex": 58,
+          "type": "Split Range"
+        }
+      ],
+      "displayName": "Distributed Union",
+      "kind": "RELATIONAL",
+      "metadata": {
+        "subquery_cluster_node": "1"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 2
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 1,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Local",
+        "subquery_cluster_node": "2"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 3
+        },
+        {
+          "childIndex": 9
+        },
+        {
+          "childIndex": 10
+        },
+        {
+          "childIndex": 11
+        },
+        {
+          "childIndex": 12
+        },
+        {
+          "childIndex": 13
+        },
+        {
+          "childIndex": 14
+        },
+        {
+          "childIndex": 14,
+          "type": "Scalar"
+        }
+      ],
+      "displayName": "Serialize Result",
+      "index": 2,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 4,
+          "variable": "SingerId"
+        },
+        {
+          "childIndex": 5,
+          "variable": "FirstName"
+        },
+        {
+          "childIndex": 6,
+          "variable": "LastName"
+        },
+        {
+          "childIndex": 7,
+          "variable": "SingerInfo"
+        },
+        {
+          "childIndex": 8,
+          "variable": "BirthDate"
+        }
+      ],
+      "displayName": "Scan",
+      "index": 3,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "Full scan": "true",
+        "scan_target": "Singers",
+        "scan_type": "TableScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 4,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SingerId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 5,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "FirstName"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 6,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "LastName"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 7,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SingerInfo"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 8,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "BirthDate"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 9,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 10,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$FirstName"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 11,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$LastName"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 12,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerInfo"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 13,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$BirthDate"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 15
+        },
+        {
+          "childIndex": 57
+        }
+      ],
+      "displayName": "Array Subquery",
+      "index": 14,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$sv_2"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 16
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 15,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Local",
+        "subquery_cluster_node": "16"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 17
+        },
+        {
+          "childIndex": 27,
+          "variable": "struct_1.SingerId"
+        },
+        {
+          "childIndex": 28,
+          "variable": "struct_1.AlbumId"
+        },
+        {
+          "childIndex": 29,
+          "variable": "struct_1.AlbumTitle"
+        },
+        {
+          "childIndex": 30,
+          "variable": "struct_1.MarketingBudget"
+        },
+        {
+          "childIndex": 31,
+          "variable": "struct_1.no_name<4>"
+        },
+        {
+          "childIndex": 31,
+          "type": "Scalar"
+        }
+      ],
+      "displayName": "Compute Struct",
+      "index": 16,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 18
+        },
+        {
+          "childIndex": 26,
+          "type": "Seek Condition"
+        }
+      ],
+      "displayName": "FilterScan",
+      "index": 17,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 19,
+          "variable": "SingerId_1"
+        },
+        {
+          "childIndex": 20,
+          "variable": "AlbumId"
+        },
+        {
+          "childIndex": 21,
+          "variable": "AlbumTitle"
+        },
+        {
+          "childIndex": 22,
+          "variable": "MarketingBudget"
+        }
+      ],
+      "displayName": "Scan",
+      "index": 18,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "scan_target": "Albums",
+        "scan_type": "TableScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 19,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SingerId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 20,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "AlbumId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 21,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "AlbumTitle"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 22,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "MarketingBudget"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 24
+        },
+        {
+          "childIndex": 25
+        }
+      ],
+      "displayName": "Function",
+      "index": 23,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($SingerId_1 = $SingerId)"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 24,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId_1"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 25,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 23
+        }
+      ],
+      "displayName": "Function",
+      "index": 26,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($SingerId_1 = $SingerId)"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 27,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId_1"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 28,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$AlbumId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 29,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$AlbumTitle"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 30,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$MarketingBudget"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 32
+        },
+        {
+          "childIndex": 56
+        }
+      ],
+      "displayName": "Array Subquery",
+      "index": 31,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$sv_1"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 33
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 32,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Local",
+        "subquery_cluster_node": "33"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 34
+        },
+        {
+          "childIndex": 50,
+          "variable": "struct.SingerId"
+        },
+        {
+          "childIndex": 51,
+          "variable": "struct.AlbumId"
+        },
+        {
+          "childIndex": 52,
+          "variable": "struct.TrackId"
+        },
+        {
+          "childIndex": 53,
+          "variable": "struct.SongName"
+        },
+        {
+          "childIndex": 54,
+          "variable": "struct.Duration"
+        },
+        {
+          "childIndex": 55,
+          "variable": "struct.SongGenre"
+        }
+      ],
+      "displayName": "Compute Struct",
+      "index": 33,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 35
+        },
+        {
+          "childIndex": 49,
+          "type": "Seek Condition"
+        }
+      ],
+      "displayName": "FilterScan",
+      "index": 34,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 36,
+          "variable": "SingerId_2"
+        },
+        {
+          "childIndex": 37,
+          "variable": "AlbumId_1"
+        },
+        {
+          "childIndex": 38,
+          "variable": "TrackId"
+        },
+        {
+          "childIndex": 39,
+          "variable": "SongName"
+        },
+        {
+          "childIndex": 40,
+          "variable": "Duration"
+        },
+        {
+          "childIndex": 41,
+          "variable": "SongGenre"
+        }
+      ],
+      "displayName": "Scan",
+      "index": 35,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "scan_target": "Songs",
+        "scan_type": "TableScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 36,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SingerId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 37,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "AlbumId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 38,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "TrackId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 39,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SongName"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 40,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "Duration"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 41,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SongGenre"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 43
+        },
+        {
+          "childIndex": 46
+        }
+      ],
+      "displayName": "Function",
+      "index": 42,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "(($SingerId_2 = $SingerId_1) AND ($AlbumId_1 = $AlbumId))"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 44
+        },
+        {
+          "childIndex": 45
+        }
+      ],
+      "displayName": "Function",
+      "index": 43,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($SingerId_2 = $SingerId_1)"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 44,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId_2"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 45,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId_1"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 47
+        },
+        {
+          "childIndex": 48
+        }
+      ],
+      "displayName": "Function",
+      "index": 46,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($AlbumId_1 = $AlbumId)"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 47,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$AlbumId_1"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 48,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$AlbumId"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 42
+        }
+      ],
+      "displayName": "Function",
+      "index": 49,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "(($SingerId_2 = $SingerId_1) AND ($AlbumId_1 = $AlbumId))"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 50,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId_2"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 51,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$AlbumId_1"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 52,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$TrackId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 53,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SongName"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 54,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$Duration"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 55,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SongGenre"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 56,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$struct"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 57,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$struct_1"
+      }
+    },
+    {
+      "displayName": "Constant",
+      "index": 58,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "true"
+      }
+    }
+  ]
+}

--- a/testdata/plans/scalar_subquery_with_filter_scan.input.json
+++ b/testdata/plans/scalar_subquery_with_filter_scan.input.json
@@ -1,0 +1,520 @@
+{
+  "planNodes": [
+    {
+      "childLinks": [
+        {
+          "childIndex": 1
+        },
+        {
+          "childIndex": 41,
+          "type": "Split Range"
+        }
+      ],
+      "displayName": "Distributed Union",
+      "kind": "RELATIONAL",
+      "metadata": {
+        "subquery_cluster_node": "1"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 2
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 1,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Local",
+        "subquery_cluster_node": "2"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 3
+        },
+        {
+          "childIndex": 35
+        },
+        {
+          "childIndex": 36
+        },
+        {
+          "childIndex": 37
+        },
+        {
+          "childIndex": 38
+        },
+        {
+          "childIndex": 39
+        },
+        {
+          "childIndex": 40
+        }
+      ],
+      "displayName": "Serialize Result",
+      "index": 2,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 4
+        },
+        {
+          "childIndex": 34,
+          "type": "Residual Condition"
+        },
+        {
+          "childIndex": 16,
+          "type": "Scalar"
+        }
+      ],
+      "displayName": "FilterScan",
+      "index": 3,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 5,
+          "variable": "SingerId"
+        },
+        {
+          "childIndex": 6,
+          "variable": "AlbumId"
+        },
+        {
+          "childIndex": 7,
+          "variable": "TrackId"
+        },
+        {
+          "childIndex": 8,
+          "variable": "SongName"
+        },
+        {
+          "childIndex": 9,
+          "variable": "Duration"
+        },
+        {
+          "childIndex": 10,
+          "variable": "SongGenre"
+        }
+      ],
+      "displayName": "Scan",
+      "index": 4,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "Full scan": "true",
+        "scan_target": "Songs",
+        "scan_type": "TableScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 5,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SingerId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 6,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "AlbumId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 7,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "TrackId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 8,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SongName"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 9,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "Duration"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 10,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SongGenre"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 12
+        },
+        {
+          "childIndex": 15
+        },
+        {
+          "childIndex": 16
+        }
+      ],
+      "displayName": "Function",
+      "index": 11,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "IF(($SongGenre = 'ROCKS'), true, $sv_1)",
+        "subqueries": {
+          "$sv_1": 16
+        }
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 13
+        },
+        {
+          "childIndex": 14
+        }
+      ],
+      "displayName": "Function",
+      "index": 12,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($SongGenre = 'ROCKS')"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 13,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SongGenre"
+      }
+    },
+    {
+      "displayName": "Constant",
+      "index": 14,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "'ROCKS'"
+      }
+    },
+    {
+      "displayName": "Constant",
+      "index": 15,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "true"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 17
+        },
+        {
+          "childIndex": 33
+        }
+      ],
+      "displayName": "Scalar Subquery",
+      "index": 16,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$sv_1"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 18
+        },
+        {
+          "childIndex": 32,
+          "type": "Agg",
+          "variable": "v1"
+        }
+      ],
+      "displayName": "Aggregate",
+      "index": 17,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Global",
+        "iterator_type": "Stream",
+        "scalar_aggregate": "true"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 19
+        },
+        {
+          "childIndex": 29,
+          "type": "Split Range"
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 18,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "subquery_cluster_node": "19"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 20
+        },
+        {
+          "childIndex": 28,
+          "type": "Agg",
+          "variable": "v2"
+        }
+      ],
+      "displayName": "Aggregate",
+      "index": 19,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Local",
+        "iterator_type": "Stream",
+        "scalar_aggregate": "true"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 21
+        }
+      ],
+      "displayName": "Distributed Union",
+      "index": 20,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "call_type": "Local",
+        "subquery_cluster_node": "21"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 22
+        },
+        {
+          "childIndex": 27,
+          "type": "Seek Condition"
+        }
+      ],
+      "displayName": "FilterScan",
+      "index": 21,
+      "kind": "RELATIONAL"
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 23,
+          "variable": "SingerId_1"
+        }
+      ],
+      "displayName": "Scan",
+      "index": 22,
+      "kind": "RELATIONAL",
+      "metadata": {
+        "scan_target": "ConcertsBySingerId",
+        "scan_type": "IndexScan"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 23,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "SingerId"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 25
+        },
+        {
+          "childIndex": 26
+        }
+      ],
+      "displayName": "Function",
+      "index": 24,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($SingerId_1 = $SingerId)"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 25,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId_1"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 26,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 24
+        }
+      ],
+      "displayName": "Function",
+      "index": 27,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($SingerId_1 = $SingerId)"
+      }
+    },
+    {
+      "displayName": "Function",
+      "index": 28,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "ANY()"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 30
+        },
+        {
+          "childIndex": 31
+        }
+      ],
+      "displayName": "Function",
+      "index": 29,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "($SingerId_1 = $SingerId)"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 30,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId_1"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 31,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId"
+      }
+    },
+    {
+      "displayName": "Function",
+      "index": 32,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "ANY()"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 33,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$v1"
+      }
+    },
+    {
+      "childLinks": [
+        {
+          "childIndex": 11
+        }
+      ],
+      "displayName": "Function",
+      "index": 34,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "IF(($SongGenre = 'ROCKS'), true, $sv_1)"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 35,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SingerId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 36,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$AlbumId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 37,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$TrackId"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 38,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SongName"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 39,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$Duration"
+      }
+    },
+    {
+      "displayName": "Reference",
+      "index": 40,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "$SongGenre"
+      }
+    },
+    {
+      "displayName": "Constant",
+      "index": 41,
+      "kind": "SCALAR",
+      "shortRepresentation": {
+        "description": "true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
#90 fixes subquery handling in Serialize Result but Compute Struct also have subqueries with `Scalar` link type because they are similar operators.
https://cloud.google.com/spanner/docs/query-execution-operators?hl=en#serialize_result
>A serialize result operator is a special case of the compute struct operator

This PR fixes the bug and simplify `IsVisible` related logics:
* Relational operators is always rendered.
* Scalar operators isn't rendered except subquery operators.
* Subquery operators are appeared with `Scalar` typed child link from relational operators.
  * (Subqueries are usually optimized, so subquery operators don't appear in other cases AFAIK.)

## Before

```sql
SELECT si.*,
  ARRAY(SELECT AS STRUCT a.*,
        ARRAY(SELECT AS STRUCT so.*
              FROM Songs so
              WHERE a.SingerId = so.SingerId AND a.AlbumId = so.AlbumId)
        FROM Albums a
        WHERE a.SingerId = si.SingerId)
FROM Singers si;
```
```
+-----+---------------------------------------------------------+
| ID  | Query_Execution_Plan (EXPERIMENTAL)                     |
+-----+---------------------------------------------------------+
|   0 | Distributed Union                                       |
|   1 | +- Local Distributed Union                              |
|   2 |    +- Serialize Result                                  |
|   3 |       +- Table Scan (Full scan: true, Table: Singers)   |
|  14 |       +- [Scalar] Array Subquery                        |
|  15 |          +- Local Distributed Union                     |
|  16 |             +- Compute Struct                           |
| *17 |                +- FilterScan                            |
|  18 |                |  +- Table Scan (Table: Albums)         |
|  31 |                +- Array Subquery                        |
|  32 |                |  +- Local Distributed Union            |
|  33 |                |     +- Compute Struct                  |
| *34 |                |        +- FilterScan                   |
|  35 |                |           +- Table Scan (Table: Songs) |
|  31 |                +- [Scalar] Array Subquery               |
|  32 |                   +- Local Distributed Union            |
|  33 |                      +- Compute Struct                  |
| *34 |                         +- FilterScan                   |
|  35 |                            +- Table Scan (Table: Songs) |
+-----+---------------------------------------------------------+
Predicates(identified by ID):
 17: Seek Condition: ($SingerId_1 = $SingerId)
 34: Seek Condition: (($SingerId_2 = $SingerId_1) AND ($AlbumId_1 = $AlbumId))
 34: Seek Condition: (($SingerId_2 = $SingerId_1) AND ($AlbumId_1 = $AlbumId))
```
## After

```
+-----+---------------------------------------------------------+
| ID  | Query_Execution_Plan (EXPERIMENTAL)                     |
+-----+---------------------------------------------------------+
|   0 | Distributed Union                                       |
|   1 | +- Local Distributed Union                              |
|   2 |    +- Serialize Result                                  |
|   3 |       +- Table Scan (Full scan: true, Table: Singers)   |
|  14 |       +- [Scalar] Array Subquery                        |
|  15 |          +- Local Distributed Union                     |
|  16 |             +- Compute Struct                           |
| *17 |                +- FilterScan                            |
|  18 |                |  +- Table Scan (Table: Albums)         |
|  31 |                +- [Scalar] Array Subquery               |
|  32 |                   +- Local Distributed Union            |
|  33 |                      +- Compute Struct                  |
| *34 |                         +- FilterScan                   |
|  35 |                            +- Table Scan (Table: Songs) |
+-----+---------------------------------------------------------+
Predicates(identified by ID):
 17: Seek Condition: ($SingerId_1 = $SingerId)
 34: Seek Condition: (($SingerId_2 = $SingerId_1) AND ($AlbumId_1 = $AlbumId))
```