### PR TITLE
TRUNCATE TABLE statement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.14
-      - image: gcr.io/cloud-spanner-emulator/emulator:0.7.3
+      - image: gcr.io/cloud-spanner-emulator/emulator:1.1.1
     steps:
       - checkout
       - run: go mod download

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The syntax is case-insensitive.
 | Create table | `CREATE TABLE ...;` | |
 | Change table schema | `ALTER TABLE ...;` | |
 | Delete table | `DROP TABLE ...;` | |
-| Truncate table | `TRUNCATE TABLE <table>;` | Only rows are deleted. |
+| Truncate table | `TRUNCATE TABLE <table>;` | Only rows are deleted. Note: Non-atomically because executed as a [partitioned DML statement](https://cloud.google.com/spanner/docs/dml-partitioned?hl=en). |
 | Create index | `CREATE INDEX ...;` | |
 | Delete index | `DROP INDEX ...;` | |
 | Query | `SELECT ...;` | |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The syntax is case-insensitive.
 | Create table | `CREATE TABLE ...;` | |
 | Change table schema | `ALTER TABLE ...;` | |
 | Delete table | `DROP TABLE ...;` | |
+| Truncate table | `TRUNCATE TABLE <table>;` | Only rows are deleted. |
 | Create index | `CREATE INDEX ...;` | |
 | Delete index | `DROP INDEX ...;` | |
 | Query | `SELECT ...;` | |

--- a/integration_test.go
+++ b/integration_test.go
@@ -685,7 +685,7 @@ func TestTruncateTable(t *testing.T) {
 
 	// We don't use the TRUNCATE TABLE's result since PartitionedUpdate may return estimated affected row counts.
 	// Instead, we check if rows are remained in the table.
-	var count int
+	var count int64
 	countStmt := spanner.NewStatement(fmt.Sprintf("SELECT COUNT(*) FROM %s", tableId))
 	if err := session.client.Single().Query(ctx, countStmt).Do(func(r *spanner.Row) error {
 		return r.Column(0, &count)

--- a/statement.go
+++ b/statement.go
@@ -705,6 +705,10 @@ func (s *TruncateTableStatement) Execute(session *Session) (*Result, error) {
 		// PartitionedUpdate creates a new transaction and it could cause dead lock with the current running transaction.
 		return nil, errors.New(`"TRUNCATE TABLE" can not be used in a read-write transaction`)
 	}
+	if session.InRoTxn() {
+		// Just for user-friendly.
+		return nil, errors.New(`"TRUNCATE TABLE" can not be used in a read-only transaction`)
+	}
 
 	stmt := spanner.NewStatement(fmt.Sprintf("DELETE FROM `%s` WHERE true", s.Table))
 	count, err := session.client.PartitionedUpdate(session.ctx, stmt)

--- a/statement.go
+++ b/statement.go
@@ -73,6 +73,7 @@ var (
 	dropTableRe      = regexp.MustCompile(`(?is)^DROP\s+TABLE\s.+$`)
 	createIndexRe    = regexp.MustCompile(`(?is)^CREATE\s+(UNIQUE\s+)?(NULL_FILTERED\s+)?INDEX\s.+$`)
 	dropIndexRe      = regexp.MustCompile(`(?is)^DROP\s+INDEX\s.+$`)
+	truncateTableRe  = regexp.MustCompile(`(?is)^TRUNCATE\s+TABLE\s+(.+)$`)
 
 	// DML
 	dmlRe = regexp.MustCompile(`(?is)^(INSERT|UPDATE|DELETE)\s+.+$`)
@@ -124,6 +125,9 @@ func BuildStatement(input string) (Statement, error) {
 		return &DdlStatement{Ddl: input}, nil
 	case dropIndexRe.MatchString(input):
 		return &DdlStatement{Ddl: input}, nil
+	case truncateTableRe.MatchString(input):
+		matched := truncateTableRe.FindStringSubmatch(input)
+		return &TruncateTableStatement{Table: unquoteIdentifier(matched[1])}, nil
 	case showDatabasesRe.MatchString(input):
 		return &ShowDatabasesStatement{}, nil
 	case showCreateTableRe.MatchString(input):
@@ -689,6 +693,27 @@ WHERE
 		ColumnNames:  columnNames,
 		Rows:         rows,
 		AffectedRows: len(rows),
+	}, nil
+}
+
+type TruncateTableStatement struct {
+	Table string
+}
+
+func (s *TruncateTableStatement) Execute(session *Session) (*Result, error) {
+	if session.InRwTxn() {
+		// PartitionedUpdate creates a new transaction and it could cause dead lock with the current running transaction.
+		return nil, errors.New(`"TRUNCATE TABLE" can not be used in a read-write transaction`)
+	}
+
+	stmt := spanner.NewStatement(fmt.Sprintf("DELETE FROM `%s` WHERE true", s.Table))
+	count, err := session.client.PartitionedUpdate(session.ctx, stmt)
+	if err != nil {
+		return nil, err
+	}
+	return &Result{
+		IsMutation:   true,
+		AffectedRows: int(count),
 	}, nil
 }
 

--- a/statement_test.go
+++ b/statement_test.go
@@ -100,6 +100,11 @@ func TestBuildStatement(t *testing.T) {
 			want:  &DdlStatement{Ddl: "DROP INDEX idx_name"},
 		},
 		{
+			desc:  "TRUNCATE TABLE statement",
+			input: "TRUNCATE TABLE t1",
+			want:  &TruncateTableStatement{Table: "t1"},
+		},
+		{
 			desc:  "INSERT statement",
 			input: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')",
 			want:  &DmlStatement{Dml: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')"},


### PR DESCRIPTION
I added `TRUNCATE TABLE <table>` statement which deletes all rows from the table.

This is useful when we want to preserve table itself but delete all rows without worrying about transaction's mutation limit. In other words, we can delete all records while preserving underlying splits.

More context: https://cloud.google.com/solutions/best-practices-cloud-spanner-gaming-database#pre-warm_the_database_before_launch