### PR TITLE
Add Partitioned DML

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ The syntax is case-insensitive.
 | Create index | `CREATE INDEX ...;` | |
 | Delete index | `DROP INDEX ...;` | |
 | Query | `SELECT ...;` | |
-| DML | `(INSERT|UPDATE|DELETE) ...;` | |
-| Partitioned DML | `PARTITIONED (UPDATE|DELETE) ...;` | |
+| DML | `(INSERT\|UPDATE\|DELETE) ...;` | |
+| Partitioned DML | `PARTITIONED (UPDATE\|DELETE) ...;` | |
 | Show Query Execution Plan | `EXPLAIN SELECT ...;` | |
 | Show DML Execution Plan | `EXPLAIN INSERT / UPDATE / DELETE ...;` | EXPERIMENTAL |
 | Show Query Execution Plan with Stats | `EXPLAIN ANALYZE SELECT ...;` | EXPERIMENTAL |
-| Show DML Execution Plan with Stats | `EXPLAIN ANALYZE (INSERT|UPDATE|DELETE) ...;` | EXPERIMENTAL |
+| Show DML Execution Plan with Stats | `EXPLAIN ANALYZE (INSERT\|UPDATE\|DELETE) ...;` | EXPERIMENTAL |
 | Start Read-Write Transaction | `BEGIN (RW);` | |
 | Commit Read-Write Transaction | `COMMIT;` | |
 | Rollback Read-Write Transaction | `ROLLBACK;` | |

--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ The syntax is case-insensitive.
 | Create index | `CREATE INDEX ...;` | |
 | Delete index | `DROP INDEX ...;` | |
 | Query | `SELECT ...;` | |
-| DML | `INSERT / UPDATE / DELETE ...;` | |
-| Partitioned DML | | Not supported yet |
+| DML | `(INSERT|UPDATE|DELETE) ...;` | |
+| Partitioned DML | `PARTITIONED (UPDATE|DELETE) ...;` | |
 | Show Query Execution Plan | `EXPLAIN SELECT ...;` | |
 | Show DML Execution Plan | `EXPLAIN INSERT / UPDATE / DELETE ...;` | EXPERIMENTAL |
 | Show Query Execution Plan with Stats | `EXPLAIN ANALYZE SELECT ...;` | EXPERIMENTAL |
-| Show DML Execution Plan with Stats | `EXPLAIN ANALYZE INSERT / UPDATE / DELETE ...;` | EXPERIMENTAL |
+| Show DML Execution Plan with Stats | `EXPLAIN ANALYZE (INSERT|UPDATE|DELETE) ...;` | EXPERIMENTAL |
 | Start Read-Write Transaction | `BEGIN (RW);` | |
 | Commit Read-Write Transaction | `COMMIT;` | |
 | Rollback Read-Write Transaction | `ROLLBACK;` | |

--- a/statement.go
+++ b/statement.go
@@ -35,15 +35,26 @@ type Statement interface {
 	Execute(session *Session) (*Result, error)
 }
 
+// rowCountType is type of modified rows count by DML.
+type rowCountType int
+
+const (
+	// rowCountTypeExact is exact count type for DML result.
+	rowCountTypeExact rowCountType = iota
+	// rowCountTypeLowerBound is lower bound type for Partitioned DML result.
+	rowCountTypeLowerBound
+)
+
 type Result struct {
-	ColumnNames  []string
-	Rows         []Row
-	Predicates   []string
-	AffectedRows int
-	Stats        QueryStats
-	IsMutation   bool
-	Timestamp    time.Time
-	ForceVerbose bool
+	ColumnNames      []string
+	Rows             []Row
+	Predicates       []string
+	AffectedRows     int
+	AffectedRowsType rowCountType
+	Stats            QueryStats
+	IsMutation       bool
+	Timestamp        time.Time
+	ForceVerbose     bool
 }
 
 type Row struct {
@@ -796,8 +807,9 @@ func (s *PartitionedDmlStatement) Execute(session *Session) (*Result, error) {
 		return nil, err
 	}
 	return &Result{
-		IsMutation:   true,
-		AffectedRows: int(count),
+		IsMutation:       true,
+		AffectedRows:     int(count),
+		AffectedRowsType: rowCountTypeLowerBound,
 	}, nil
 }
 

--- a/statement_test.go
+++ b/statement_test.go
@@ -120,6 +120,16 @@ func TestBuildStatement(t *testing.T) {
 			want:  &DmlStatement{Dml: "DELETE FROM t1 WHERE id = 1"},
 		},
 		{
+			desc:  "PARTITIONED UPDATE statement",
+			input: "PARTITIONED UPDATE t1 SET name = hello WHERE id > 1",
+			want:  &PartitionedDmlStatement{Dml: "UPDATE t1 SET name = hello WHERE id > 1"},
+		},
+		{
+			desc:  "PARTITIONED DELETE statement",
+			input: "PARTITIONED DELETE FROM t1 WHERE id > 1",
+			want:  &PartitionedDmlStatement{Dml: "DELETE FROM t1 WHERE id > 1"},
+		},
+		{
 			desc:  "EXPLAIN INSERT statement",
 			input: "EXPLAIN INSERT INTO t1 (id, name) VALUES (1, 'yuki')",
 			want:  &ExplainDmlStatement{Dml: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')"},


### PR DESCRIPTION
## Syntax:

`PARTITIONED (UPDATE|DELETE) ...;`

## Example:
```
spanner> select * from Songs;
+----------+---------+---------+-------------------------+----------+-----------+
| SingerId | AlbumId | TrackId | SongName                | Duration | SongGenre |
+----------+---------+---------+-------------------------+----------+-----------+
| 2        | 1       | 1       | Let's Get Back Together | 182      | COUNTRY   |
| 2        | 1       | 2       | Starting Again          | 156      | ROCK      |
| 2        | 1       | 3       | I Knew You Were Magic   | 294      | BLUES     |
| 2        | 1       | 4       | 42                      | 185      | CLASSICAL |
| 2        | 1       | 5       | Blue                    | 238      | BLUES     |
| 2        | 1       | 6       | Nothing Is The Same     | 303      | BLUES     |
| 2        | 1       | 7       | The Second Time         | 255      | ROCK      |
| 2        | 3       | 1       | Fight Story             | 194      | ROCK      |
| 3        | 1       | 1       | Not About The Guitar    | 278      | BLUES     |
+----------+---------+---------+-------------------------+----------+-----------+
9 rows in set (5.48 msecs)

spanner> partitioned update Songs set SongName = "Foo Bar" WHERE SongGenre = 'ROCK';
Query OK, 3 rows affected (3.75 sec)

spanner> select * from Songs;
+----------+---------+---------+-------------------------+----------+-----------+
| SingerId | AlbumId | TrackId | SongName                | Duration | SongGenre |
+----------+---------+---------+-------------------------+----------+-----------+
| 2        | 1       | 1       | Let's Get Back Together | 182      | COUNTRY   |
| 2        | 1       | 2       | Foo Bar                 | 156      | ROCK      |
| 2        | 1       | 3       | I Knew You Were Magic   | 294      | BLUES     |
| 2        | 1       | 4       | 42                      | 185      | CLASSICAL |
| 2        | 1       | 5       | Blue                    | 238      | BLUES     |
| 2        | 1       | 6       | Nothing Is The Same     | 303      | BLUES     |
| 2        | 1       | 7       | Foo Bar                 | 255      | ROCK      |
| 2        | 3       | 1       | Foo Bar                 | 194      | ROCK      |
| 3        | 1       | 1       | Not About The Guitar    | 278      | BLUES     |
+----------+---------+---------+-------------------------+----------+-----------+
9 rows in set (51.09 msecs)

spanner> partitioned delete from Songs WHERE SongGenre = 'ROCK';
Query OK, 3 rows affected (3.30 sec)

spanner> select * from Songs;
+----------+---------+---------+-------------------------+----------+-----------+
| SingerId | AlbumId | TrackId | SongName                | Duration | SongGenre |
+----------+---------+---------+-------------------------+----------+-----------+
| 2        | 1       | 1       | Let's Get Back Together | 182      | COUNTRY   |
| 2        | 1       | 3       | I Knew You Were Magic   | 294      | BLUES     |
| 2        | 1       | 4       | 42                      | 185      | CLASSICAL |
| 2        | 1       | 5       | Blue                    | 238      | BLUES     |
| 2        | 1       | 6       | Nothing Is The Same     | 303      | BLUES     |
| 3        | 1       | 1       | Not About The Guitar    | 278      | BLUES     |
+----------+---------+---------+-------------------------+----------+-----------+
6 rows in set (6.84 msecs)
```

close: https://github.com/cloudspannerecosystem/spanner-cli/issues/93