### PR TITLE
Finish read-write transaction when SELECT statement was aborted

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/api/iterator"
 	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
 	pb "google.golang.org/genproto/googleapis/spanner/v1"
+	"google.golang.org/grpc/codes"
 )
 
 type Statement interface {
@@ -219,7 +220,7 @@ func (s *SelectStatement) Execute(session *Session) (*Result, error) {
 
 	rows, columnNames, err := parseQueryResult(iter)
 	if err != nil {
-		if session.InRwTxn() {
+		if session.InRwTxn() && spanner.ErrCode(err) == codes.Aborted {
 			// Need to call rollback to free the acquired session in underlying google-cloud-go/spanner.
 			rollback := &RollbackStatement{}
 			rollback.Execute(session)

--- a/statement.go
+++ b/statement.go
@@ -219,6 +219,11 @@ func (s *SelectStatement) Execute(session *Session) (*Result, error) {
 
 	rows, columnNames, err := parseQueryResult(iter)
 	if err != nil {
+		if session.InRwTxn() {
+			// Need to call rollback to free the acquired session in underlying google-cloud-go/spanner.
+			rollback := &RollbackStatement{}
+			rollback.Execute(session)
+		}
 		return nil, err
 	}
 	result := &Result{


### PR DESCRIPTION
This PR fixed a bug that the read-write transaction doesn't finish when the execution of SELECT statement returns `codes.Aborted`.

## Behavior

```
> BEGIN RW;
Query OK, 0 rows affected (0.01 sec)

(rw txn)> @{LOCK_SCANNED_RANGES=exclusive} SELECT * FROM tbl WHERE pk = 0;
Empty set (10.44 msecs)

(rw txn)> @{LOCK_SCANNED_RANGES=exclusive} SELECT * FROM tbl WHERE pk = 0;
ERROR: spanner: code = "Aborted", desc = "Transaction was aborted."
>  
```

This PR doesn't change the behavior of codes other than `codes.Aborted` so syntax error doesn't abort transaction. It seems user friendly.

```
(rw txn)> SELECT * FROM tbl WHERE pk = '';
ERROR: spanner: code = "InvalidArgument", desc = "No matching signature for operator = for argument types: INT64, STRING. Supported signature: ANY = ANY [at 1:25]\\nSELECT * FROM tbl WHERE pk = \\'\\'\\n                        ^"
(rw txn)> 
```

closes #95 