### PR TITLE
Recreate session if transaction is aborted

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -83,9 +83,7 @@ func setup(t *testing.T, ctx context.Context, dmls []string) (*Session, string, 
 	if testCredential != "" {
 		options = append(options, option.WithCredentialsJSON([]byte(testCredential)))
 	}
-	session, err := NewSession(ctx, testProjectId, testInstanceId, testDatabaseId, spanner.ClientConfig{
-		SessionPoolConfig: spanner.SessionPoolConfig{WriteSessions: 0.2},
-	}, options...)
+	session, err := NewSession(ctx, testProjectId, testInstanceId, testDatabaseId, options...)
 	if err != nil {
 		t.Fatalf("failed to create test session: err=%s", err)
 	}

--- a/session.go
+++ b/session.go
@@ -34,8 +34,8 @@ type txnFinishResult struct {
 
 var clientConfig = spanner.ClientConfig{
 	SessionPoolConfig: spanner.SessionPoolConfig{
-		MaxOpened: 1,
 		MinOpened: 1,
+		MaxOpened: 10, // FIXME: integration_test requires more than a single session
 	},
 }
 

--- a/session.go
+++ b/session.go
@@ -19,19 +19,28 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"cloud.google.com/go/spanner"
 	adminapi "cloud.google.com/go/spanner/admin/database/apiv1"
 	"google.golang.org/api/option"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
 
 type txnFinishResult struct {
 	CommitTimestamp time.Time
 	Err             error
+}
+
+var clientConfig = spanner.ClientConfig{
+	SessionPoolConfig: spanner.SessionPoolConfig{
+		MaxOpened: 1,
+		MinOpened: 1,
+	},
+}
+
+var defaultClientOpts = []option.ClientOption{
+	option.WithGRPCConnectionPool(1),
 }
 
 type Session struct {
@@ -41,6 +50,7 @@ type Session struct {
 	databaseId  string
 	client      *spanner.Client
 	adminClient *adminapi.DatabaseAdminClient
+	clientOpts  []option.ClientOption
 
 	// for read-write transaction
 	rwTxn         *spanner.ReadWriteStmtBasedTransaction
@@ -50,20 +60,13 @@ type Session struct {
 	roTxn *spanner.ReadOnlyTransaction
 }
 
-func NewSession(ctx context.Context, projectId string, instanceId string, databaseId string, clientConfig spanner.ClientConfig, opts ...option.ClientOption) (*Session, error) {
+func NewSession(ctx context.Context, projectId string, instanceId string, databaseId string, opts ...option.ClientOption) (*Session, error) {
 	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectId, instanceId, databaseId)
+	opts = append(opts, defaultClientOpts...)
+
 	client, err := spanner.NewClientWithConfig(ctx, dbPath, clientConfig, opts...)
 	if err != nil {
 		return nil, err
-	}
-
-	if emulatorAddr := os.Getenv("SPANNER_EMULATOR_HOST"); emulatorAddr != "" {
-		emulatorOpts := []option.ClientOption{
-			option.WithEndpoint(emulatorAddr),
-			option.WithGRPCDialOption(grpc.WithInsecure()),
-			option.WithoutAuthentication(),
-		}
-		opts = append(opts, emulatorOpts...)
 	}
 
 	adminClient, err := adminapi.NewDatabaseAdminClient(ctx, opts...)
@@ -77,6 +80,7 @@ func NewSession(ctx context.Context, projectId string, instanceId string, databa
 		instanceId:  instanceId,
 		databaseId:  databaseId,
 		client:      client,
+		clientOpts:  opts,
 		adminClient: adminClient,
 	}, nil
 }
@@ -139,6 +143,17 @@ func (s *Session) DatabaseExists() (bool, error) {
 	default:
 		return false, fmt.Errorf("checking database existence failed: %v", err)
 	}
+}
+
+// RecreateClient closes the current client and creates a new client for the session.
+func (s *Session) RecreateClient() error {
+	c, err := spanner.NewClientWithConfig(s.ctx, s.DatabasePath(), clientConfig, s.clientOpts...)
+	if err != nil {
+		return err
+	}
+	s.client.Close()
+	s.client = c
+	return nil
 }
 
 // StartHeartbeat starts heartbeat for read-write transaction.


### PR DESCRIPTION
I have found that Cloud Spanner has a mechanism to increase the lock priority of the session if a transaction on the session was aborted: https://cloud.google.com/spanner/docs/reference/rest/v1/TransactionOptions#retrying-aborted-transactions

This mechanism looks fine for real-world application to prevent the same transaction from being wounded multiple times, but in spanner-cli, it makes the result of subsequent transaction inconsistent. See #98 for example.

To make the result of the transaction consistent over subsequent transactions, I changed the CLI to recreate the Cloud Spanner's session if transaction is aborted.

close: #98