### PR TITLE
Defer transaction heartbeat

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -279,9 +279,9 @@ func (c *Cli) getInterpolatedPrompt() string {
 	prompt = promptReInstanceId.ReplaceAllString(prompt, c.Session.instanceId)
 	prompt = promptReDatabaseId.ReplaceAllString(prompt, c.Session.databaseId)
 
-	if c.Session.InRwTxn() {
+	if c.Session.InReadWriteTransaction() {
 		prompt = promptReInTransaction.ReplaceAllString(prompt, "(rw txn)")
-	} else if c.Session.InRoTxn() {
+	} else if c.Session.InReadOnlyTransaction() {
 		prompt = promptReInTransaction.ReplaceAllString(prompt, "(ro txn)")
 	} else {
 		prompt = promptReInTransaction.ReplaceAllString(prompt, "")

--- a/session.go
+++ b/session.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -51,7 +52,9 @@ type Session struct {
 	clientOpts  []option.ClientOption
 
 	// for read-write transaction
-	rwTxn         *spanner.ReadWriteStmtBasedTransaction
+	rwTxn *spanner.ReadWriteStmtBasedTransaction
+	// rwTxn is supposed to be accessed concurrently from transaction handling and heartbeat,
+	// so we will use mutex to guard a critical section.
 	rwTxnMutex    sync.Mutex
 	sendHeartbeat bool
 
@@ -87,15 +90,22 @@ func NewSession(ctx context.Context, projectId string, instanceId string, databa
 	return session, nil
 }
 
+// InReadWriteTransaction returns true if the session is running read-write transaction.
 func (s *Session) InReadWriteTransaction() bool {
 	return s.rwTxn != nil
 }
 
+// InReadOnlyTransaction returns true if the session is running read-only transaction.
 func (s *Session) InReadOnlyTransaction() bool {
 	return s.roTxn != nil
 }
 
+// BeginReadWriteTransaction starts read-write transaction.
 func (s *Session) BeginReadWriteTransaction() error {
+	if s.rwTxn != nil {
+		return errors.New("read-write transaction is already running")
+	}
+
 	txn, err := spanner.NewReadWriteStmtBasedTransaction(s.ctx, s.client)
 	if err != nil {
 		return err
@@ -104,9 +114,10 @@ func (s *Session) BeginReadWriteTransaction() error {
 	return nil
 }
 
+// CommitReadWriteTransaction commits read-write transaction and returns commit timestamp if successful.
 func (s *Session) CommitReadWriteTransaction() (time.Time, error) {
 	if s.rwTxn == nil {
-		// TODO: error
+		return time.Time{}, errors.New("read-write transaction is not running")
 	}
 
 	s.rwTxnMutex.Lock()
@@ -118,9 +129,10 @@ func (s *Session) CommitReadWriteTransaction() (time.Time, error) {
 	return ts, err
 }
 
-func (s *Session) RollbackReadWriteTransaction() {
+// RollbackReadWriteTransaction rollbacks read-write transaction.
+func (s *Session) RollbackReadWriteTransaction() error {
 	if s.rwTxn == nil {
-		// TODO: error
+		return errors.New("read-write transaction is not running")
 	}
 
 	s.rwTxnMutex.Lock()
@@ -129,9 +141,16 @@ func (s *Session) RollbackReadWriteTransaction() {
 	s.rwTxn.Rollback(s.ctx)
 	s.rwTxn = nil
 	s.sendHeartbeat = false
+
+	return nil
 }
 
+// BeginReadOnlyTransaction starts read-only transaction and returns the snapshot timestamp for the transaction if successful.
 func (s *Session) BeginReadOnlyTransaction(typ timestampBoundType, staleness time.Duration, timestamp time.Time) (time.Time, error) {
+	if s.roTxn != nil {
+		return time.Time{}, errors.New("read-only transaction is already running")
+	}
+
 	txn := s.client.ReadOnlyTransaction()
 	switch typ {
 	case strong:
@@ -155,57 +174,74 @@ func (s *Session) BeginReadOnlyTransaction(typ timestampBoundType, staleness tim
 	return txn.Timestamp()
 }
 
-func (s *Session) CloseReadOnlyTransaction() {
+// CloseReadOnlyTransaction closes a running read-only transaction.
+func (s *Session) CloseReadOnlyTransaction() error {
 	if s.roTxn == nil {
-		// TODO: error
+		return errors.New("read-only transaction is not running")
 	}
+
 	s.roTxn.Close()
 	s.roTxn = nil
+	return nil
 }
 
+// RunQueryWithStats executes a statement with stats either on the running transaction or on the temporal read-only transaction.
+// It returns row iterator and read-only transaction if the statement was executed on the read-only transaction.
 func (s *Session) RunQueryWithStats(stmt spanner.Statement) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
 	if s.rwTxn != nil {
-		defer func() { s.sendHeartbeat = true }()
-		return s.rwTxn.QueryWithStats(s.ctx, stmt), nil
-	} else if s.roTxn != nil {
-		return s.roTxn.QueryWithStats(s.ctx, stmt), s.roTxn
-	} else {
-		txn := s.client.Single()
-		return txn.QueryWithStats(s.ctx, stmt), txn
+		iter := s.rwTxn.QueryWithStats(s.ctx, stmt)
+		s.sendHeartbeat = true
+		return iter, nil
 	}
+	if s.roTxn != nil {
+		return s.roTxn.QueryWithStats(s.ctx, stmt), s.roTxn
+	}
+
+	txn := s.client.Single()
+	return txn.QueryWithStats(s.ctx, stmt), txn
 }
 
+// RunQuery executes a statement either on the running transaction or on the temporal read-only transaction.
+// It returns row iterator and read-only transaction if the statement was executed on the read-only transaction.
 func (s *Session) RunQuery(stmt spanner.Statement) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
 	if s.rwTxn != nil {
-		defer func() { s.sendHeartbeat = true }()
-		return s.rwTxn.Query(s.ctx, stmt), nil
-	} else if s.roTxn != nil {
-		return s.roTxn.Query(s.ctx, stmt), s.roTxn
-	} else {
-		txn := s.client.Single()
-		return txn.Query(s.ctx, stmt), txn
+		iter := s.rwTxn.Query(s.ctx, stmt)
+		s.sendHeartbeat = true
+		return iter, nil
 	}
+	if s.roTxn != nil {
+		return s.roTxn.Query(s.ctx, stmt), s.roTxn
+	}
+
+	txn := s.client.Single()
+	return txn.Query(s.ctx, stmt), txn
 }
 
+// RunAnalyzeQuery analyzes a statement either on the running transaction or on the temporal read-only transaction.
 func (s *Session) RunAnalyzeQuery(stmt spanner.Statement) (*pb.QueryPlan, error) {
 	if s.rwTxn != nil {
-		defer func() { s.sendHeartbeat = true }()
-		return s.rwTxn.AnalyzeQuery(s.ctx, stmt)
-	} else if s.roTxn != nil {
-		return s.roTxn.AnalyzeQuery(s.ctx, stmt)
-	} else {
-		txn := s.client.Single()
-		return txn.AnalyzeQuery(s.ctx, stmt)
+		plan, err := s.rwTxn.AnalyzeQuery(s.ctx, stmt)
+		s.sendHeartbeat = true
+		return plan, err
 	}
+	if s.roTxn != nil {
+		return s.roTxn.AnalyzeQuery(s.ctx, stmt)
+	}
+
+	txn := s.client.Single()
+	return txn.AnalyzeQuery(s.ctx, stmt)
 }
 
+// RunUpdate executes a DML statement on the running read-write transaction.
+// It returns error if there is no running read-write transaction.
 func (s *Session) RunUpdate(stmt spanner.Statement) (int64, error) {
 	if s.rwTxn == nil {
-		// TODO: error
+		return 0, errors.New("read-write transaction is not running")
 	}
 
-	defer func() { s.sendHeartbeat = true }()
-	return s.rwTxn.Update(s.ctx, stmt)
+	rowCount, err := s.rwTxn.Update(s.ctx, stmt)
+	s.sendHeartbeat = true
+	return rowCount, err
 }
 
 func (s *Session) Close() {
@@ -259,6 +295,10 @@ func (s *Session) RecreateClient() error {
 // If no reads or DMLs happen within 10 seconds, the rw-transaction is considered idle at Cloud Spanner server.
 // This "SELECT 1" query prevents the transaction from being considered idle.
 // cf. https://godoc.org/cloud.google.com/go/spanner#hdr-Idle_transactions
+//
+// We send an actual heartbeat only if the transaction is active and
+// at least one user-initialized SQL query has been executed.
+// See: https://github.com/cloudspannerecosystem/spanner-cli/issues/100
 func (s *Session) startHeartbeat() {
 	interval := time.NewTicker(5 * time.Second)
 	defer interval.Stop()

--- a/session.go
+++ b/session.go
@@ -296,9 +296,9 @@ func (s *Session) RecreateClient() error {
 // This "SELECT 1" query prevents the transaction from being considered idle.
 // cf. https://godoc.org/cloud.google.com/go/spanner#hdr-Idle_transactions
 //
-// We send an actual heartbeat only if the transaction is active and
-// at least one user-initialized SQL query has been executed.
-// See: https://github.com/cloudspannerecosystem/spanner-cli/issues/100
+// We send an actual heartbeat only if the read-write transaction is active and
+// at least one user-initialized SQL query has been executed on the transaction.
+// Background: https://github.com/cloudspannerecosystem/spanner-cli/issues/100
 func (s *Session) startHeartbeat() {
 	interval := time.NewTicker(5 * time.Second)
 	defer interval.Stop()

--- a/session.go
+++ b/session.go
@@ -19,18 +19,16 @@ package main
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/spanner"
-	adminapi "cloud.google.com/go/spanner/admin/database/apiv1"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
-)
 
-type txnFinishResult struct {
-	CommitTimestamp time.Time
-	Err             error
-}
+	adminapi "cloud.google.com/go/spanner/admin/database/apiv1"
+	pb "google.golang.org/genproto/googleapis/spanner/v1"
+)
 
 var clientConfig = spanner.ClientConfig{
 	SessionPoolConfig: spanner.SessionPoolConfig{
@@ -54,7 +52,8 @@ type Session struct {
 
 	// for read-write transaction
 	rwTxn         *spanner.ReadWriteStmtBasedTransaction
-	heartbeatChan chan bool
+	rwTxnMutex    sync.Mutex
+	sendHeartbeat bool
 
 	// for read-only transaction
 	roTxn *spanner.ReadOnlyTransaction
@@ -74,7 +73,7 @@ func NewSession(ctx context.Context, projectId string, instanceId string, databa
 		return nil, err
 	}
 
-	return &Session{
+	session := &Session{
 		ctx:         ctx,
 		projectId:   projectId,
 		instanceId:  instanceId,
@@ -82,32 +81,131 @@ func NewSession(ctx context.Context, projectId string, instanceId string, databa
 		client:      client,
 		clientOpts:  opts,
 		adminClient: adminClient,
-	}, nil
+	}
+	go session.startHeartbeat()
+
+	return session, nil
 }
 
-func (s *Session) StartRwTxn(txn *spanner.ReadWriteStmtBasedTransaction) {
+func (s *Session) InReadWriteTransaction() bool {
+	return s.rwTxn != nil
+}
+
+func (s *Session) InReadOnlyTransaction() bool {
+	return s.roTxn != nil
+}
+
+func (s *Session) BeginReadWriteTransaction() error {
+	txn, err := spanner.NewReadWriteStmtBasedTransaction(s.ctx, s.client)
+	if err != nil {
+		return err
+	}
 	s.rwTxn = txn
+	return nil
 }
 
-func (s *Session) FinishRwTxn() {
+func (s *Session) CommitReadWriteTransaction() (time.Time, error) {
+	if s.rwTxn == nil {
+		// TODO: error
+	}
+
+	s.rwTxnMutex.Lock()
+	defer s.rwTxnMutex.Unlock()
+
+	ts, err := s.rwTxn.Commit(s.ctx)
 	s.rwTxn = nil
+	s.sendHeartbeat = false
+	return ts, err
 }
 
-func (s *Session) StartRoTxn(txn *spanner.ReadOnlyTransaction) {
+func (s *Session) RollbackReadWriteTransaction() {
+	if s.rwTxn == nil {
+		// TODO: error
+	}
+
+	s.rwTxnMutex.Lock()
+	defer s.rwTxnMutex.Unlock()
+
+	s.rwTxn.Rollback(s.ctx)
+	s.rwTxn = nil
+	s.sendHeartbeat = false
+}
+
+func (s *Session) BeginReadOnlyTransaction(typ timestampBoundType, staleness time.Duration, timestamp time.Time) (time.Time, error) {
+	txn := s.client.ReadOnlyTransaction()
+	switch typ {
+	case strong:
+		txn = txn.WithTimestampBound(spanner.StrongRead())
+	case exactStaleness:
+		txn = txn.WithTimestampBound(spanner.ExactStaleness(staleness))
+	case readTimestamp:
+		txn = txn.WithTimestampBound(spanner.ReadTimestamp(timestamp))
+	}
+
+	// Because google-cloud-go/spanner defers calling BeginTransaction RPC until an actual query is run,
+	// we explicitly run a "SELECT 1" query so that we can determine the timestamp of read-only transaction.
+	if err := txn.Query(s.ctx, spanner.NewStatement("SELECT 1")).Do(func(r *spanner.Row) error {
+		return nil
+	}); err != nil {
+		return time.Time{}, err
+	}
+
 	s.roTxn = txn
+
+	return txn.Timestamp()
 }
 
-func (s *Session) FinishRoTxn() {
+func (s *Session) CloseReadOnlyTransaction() {
+	if s.roTxn == nil {
+		// TODO: error
+	}
 	s.roTxn.Close()
 	s.roTxn = nil
 }
 
-func (s *Session) InRwTxn() bool {
-	return s.rwTxn != nil
+func (s *Session) RunQueryWithStats(stmt spanner.Statement) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
+	if s.rwTxn != nil {
+		defer func() { s.sendHeartbeat = true }()
+		return s.rwTxn.QueryWithStats(s.ctx, stmt), nil
+	} else if s.roTxn != nil {
+		return s.roTxn.QueryWithStats(s.ctx, stmt), s.roTxn
+	} else {
+		txn := s.client.Single()
+		return txn.QueryWithStats(s.ctx, stmt), txn
+	}
 }
 
-func (s *Session) InRoTxn() bool {
-	return s.roTxn != nil
+func (s *Session) RunQuery(stmt spanner.Statement) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
+	if s.rwTxn != nil {
+		defer func() { s.sendHeartbeat = true }()
+		return s.rwTxn.Query(s.ctx, stmt), nil
+	} else if s.roTxn != nil {
+		return s.roTxn.Query(s.ctx, stmt), s.roTxn
+	} else {
+		txn := s.client.Single()
+		return txn.Query(s.ctx, stmt), txn
+	}
+}
+
+func (s *Session) RunAnalyzeQuery(stmt spanner.Statement) (*pb.QueryPlan, error) {
+	if s.rwTxn != nil {
+		defer func() { s.sendHeartbeat = true }()
+		return s.rwTxn.AnalyzeQuery(s.ctx, stmt)
+	} else if s.roTxn != nil {
+		return s.roTxn.AnalyzeQuery(s.ctx, stmt)
+	} else {
+		txn := s.client.Single()
+		return txn.AnalyzeQuery(s.ctx, stmt)
+	}
+}
+
+func (s *Session) RunUpdate(stmt spanner.Statement) (int64, error) {
+	if s.rwTxn == nil {
+		// TODO: error
+	}
+
+	defer func() { s.sendHeartbeat = true }()
+	return s.rwTxn.Update(s.ctx, stmt)
 }
 
 func (s *Session) Close() {
@@ -156,37 +254,25 @@ func (s *Session) RecreateClient() error {
 	return nil
 }
 
-// StartHeartbeat starts heartbeat for read-write transaction.
+// startHeartbeat starts heartbeat for read-write transaction.
 //
 // If no reads or DMLs happen within 10 seconds, the rw-transaction is considered idle at Cloud Spanner server.
 // This "SELECT 1" query prevents the transaction from being considered idle.
 // cf. https://godoc.org/cloud.google.com/go/spanner#hdr-Idle_transactions
-func (s *Session) StartHeartbeat() {
+func (s *Session) startHeartbeat() {
 	interval := time.NewTicker(5 * time.Second)
-	timeout := time.NewTimer(600 * time.Second)
-	stop := make(chan bool)
-	go func() {
-		defer interval.Stop()
-		defer timeout.Stop()
+	defer interval.Stop()
 
-		for {
-			select {
-			case <-interval.C:
-				if err := heartbeat(s.ctx, s.rwTxn); err != nil {
-					return
-				}
-			case <-timeout.C:
-				return
-			case <-stop:
-				return
+	for {
+		select {
+		case <-interval.C:
+			s.rwTxnMutex.Lock()
+			if s.rwTxn != nil && s.sendHeartbeat {
+				heartbeat(s.ctx, s.rwTxn)
 			}
+			s.rwTxnMutex.Unlock()
 		}
-	}()
-	s.heartbeatChan = stop
-}
-
-func (s *Session) StopHeartbeat() {
-	close(s.heartbeatChan)
+	}
 }
 
 func heartbeat(ctx context.Context, txn *spanner.ReadWriteStmtBasedTransaction) error {

--- a/statement.go
+++ b/statement.go
@@ -929,7 +929,9 @@ func (s *RollbackStatement) Execute(session *Session) (*Result, error) {
 		return result, nil
 	}
 
-	session.RollbackReadWriteTransaction()
+	if err := session.RollbackReadWriteTransaction(); err != nil {
+		return nil, err
+	}
 
 	return result, nil
 }
@@ -1004,7 +1006,9 @@ func (s *CloseStatement) Execute(session *Session) (*Result, error) {
 		return result, nil
 	}
 
-	session.CloseReadOnlyTransaction()
+	if err := session.CloseReadOnlyTransaction(); err != nil {
+		return nil, err
+	}
 
 	return result, nil
 }

--- a/statement.go
+++ b/statement.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -204,23 +203,13 @@ type SelectStatement struct {
 
 func (s *SelectStatement) Execute(session *Session) (*Result, error) {
 	stmt := spanner.NewStatement(s.Query)
-	var iter *spanner.RowIterator
 
-	var targetRoTxn *spanner.ReadOnlyTransaction
-	if session.InRwTxn() {
-		iter = session.rwTxn.QueryWithStats(session.ctx, stmt)
-	} else if session.InRoTxn() {
-		targetRoTxn = session.roTxn
-		iter = targetRoTxn.QueryWithStats(session.ctx, stmt)
-	} else {
-		targetRoTxn = session.client.Single()
-		iter = targetRoTxn.QueryWithStats(session.ctx, stmt)
-	}
+	iter, roTxn := session.RunQueryWithStats(stmt)
 	defer iter.Stop()
 
 	rows, columnNames, err := parseQueryResult(iter)
 	if err != nil {
-		if session.InRwTxn() && spanner.ErrCode(err) == codes.Aborted {
+		if session.InReadWriteTransaction() && spanner.ErrCode(err) == codes.Aborted {
 			// Need to call rollback to free the acquired session in underlying google-cloud-go/spanner.
 			rollback := &RollbackStatement{}
 			rollback.Execute(session)
@@ -242,8 +231,8 @@ func (s *SelectStatement) Execute(session *Session) (*Result, error) {
 	result.Stats = queryStats
 
 	// ReadOnlyTransaction.Timestamp() is invalid until read.
-	if targetRoTxn != nil {
-		result.Timestamp, _ = targetRoTxn.Timestamp()
+	if roTxn != nil {
+		result.Timestamp, _ = roTxn.Timestamp()
 	}
 
 	return result, nil
@@ -452,7 +441,7 @@ func isCreateTableDDL(ddl string, table string) bool {
 type ShowTablesStatement struct{}
 
 func (s *ShowTablesStatement) Execute(session *Session) (*Result, error) {
-	if session.InRwTxn() {
+	if session.InReadWriteTransaction() {
 		// INFORMATION_SCHEMA can not be used in read-write transaction.
 		// https://cloud.google.com/spanner/docs/information-schema
 		return nil, errors.New(`"SHOW TABLES" can not be used in a read-write transaction`)
@@ -461,13 +450,7 @@ func (s *ShowTablesStatement) Execute(session *Session) (*Result, error) {
 	alias := fmt.Sprintf("Tables_in_%s", session.databaseId)
 	stmt := spanner.NewStatement(fmt.Sprintf("SELECT t.TABLE_NAME AS `%s` FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_CATALOG = '' and t.TABLE_SCHEMA = ''", alias))
 
-	var txn *spanner.ReadOnlyTransaction
-	if session.InRoTxn() {
-		txn = session.roTxn
-	} else {
-		txn = session.client.Single()
-	}
-	iter := txn.Query(session.ctx, stmt)
+	iter, _ := session.RunQuery(stmt)
 	defer iter.Stop()
 
 	rows, columnNames, err := parseQueryResult(iter)
@@ -514,19 +497,9 @@ type ExplainAnalyzeStatement struct {
 
 func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
 	stmt := spanner.NewStatement(s.Query)
-	var iter *spanner.RowIterator
 
-	var targetRoTxn *spanner.ReadOnlyTransaction
-	if session.InRwTxn() {
-		iter = session.rwTxn.QueryWithStats(session.ctx, stmt)
-	} else if session.InRoTxn() {
-		targetRoTxn = session.roTxn
-		iter = targetRoTxn.QueryWithStats(session.ctx, stmt)
-	} else {
-		targetRoTxn = session.client.Single()
-		iter = targetRoTxn.QueryWithStats(session.ctx, stmt)
-	}
-	defer iter.Stop()
+	iter, roTxn := session.RunQueryWithStats(stmt)
+
 	// consume iter
 	err := iter.Do(func(*spanner.Row) error {
 		return nil
@@ -554,8 +527,8 @@ func (s *ExplainAnalyzeStatement) Execute(session *Session) (*Result, error) {
 
 	// ReadOnlyTransaction.Timestamp() is invalid until read.
 	var timestamp time.Time
-	if targetRoTxn != nil {
-		timestamp, _ = targetRoTxn.Timestamp()
+	if roTxn != nil {
+		timestamp, _ = roTxn.Timestamp()
 	}
 
 	result := &Result{
@@ -619,7 +592,7 @@ type ShowColumnsStatement struct {
 }
 
 func (s *ShowColumnsStatement) Execute(session *Session) (*Result, error) {
-	if session.InRwTxn() {
+	if session.InReadWriteTransaction() {
 		// INFORMATION_SCHEMA can not be used in read-write transaction.
 		// https://cloud.google.com/spanner/docs/information-schema
 		return nil, errors.New(`"SHOW COLUMNS" can not be used in a read-write transaction`)
@@ -646,13 +619,7 @@ ORDER BY
   C.ORDINAL_POSITION ASC`,
 		Params: map[string]interface{}{"table_name": s.Table}}
 
-	var txn *spanner.ReadOnlyTransaction
-	if session.InRoTxn() {
-		txn = session.roTxn
-	} else {
-		txn = session.client.Single()
-	}
-	iter := txn.Query(session.ctx, stmt)
+	iter, _ := session.RunQuery(stmt)
 	defer iter.Stop()
 
 	rows, columnNames, err := parseQueryResult(iter)
@@ -675,7 +642,7 @@ type ShowIndexStatement struct {
 }
 
 func (s *ShowIndexStatement) Execute(session *Session) (*Result, error) {
-	if session.InRwTxn() {
+	if session.InReadWriteTransaction() {
 		// INFORMATION_SCHEMA can not be used in read-write transaction.
 		// https://cloud.google.com/spanner/docs/information-schema
 		return nil, errors.New(`"SHOW INDEX" can not be used in a read-write transaction`)
@@ -696,14 +663,7 @@ WHERE
   I.TABLE_SCHEMA = '' AND LOWER(TABLE_NAME) = LOWER(@table_name)`,
 		Params: map[string]interface{}{"table_name": s.Table}}
 
-	var txn *spanner.ReadOnlyTransaction
-	if session.InRoTxn() {
-		txn = session.roTxn
-	} else {
-		txn = session.client.Single()
-	}
-
-	iter := txn.Query(session.ctx, stmt)
+	iter, _ := session.RunQuery(stmt)
 	defer iter.Stop()
 
 	rows, columnNames, err := parseQueryResult(iter)
@@ -726,11 +686,11 @@ type TruncateTableStatement struct {
 }
 
 func (s *TruncateTableStatement) Execute(session *Session) (*Result, error) {
-	if session.InRwTxn() {
+	if session.InReadWriteTransaction() {
 		// PartitionedUpdate creates a new transaction and it could cause dead lock with the current running transaction.
 		return nil, errors.New(`"TRUNCATE TABLE" can not be used in a read-write transaction`)
 	}
-	if session.InRoTxn() {
+	if session.InReadOnlyTransaction() {
 		// Just for user-friendly.
 		return nil, errors.New(`"TRUNCATE TABLE" can not be used in a read-only transaction`)
 	}
@@ -757,8 +717,8 @@ func (s *DmlStatement) Execute(session *Session) (*Result, error) {
 
 	var numRows int64
 	var err error
-	if session.InRwTxn() {
-		numRows, err = session.rwTxn.Update(session.ctx, stmt)
+	if session.InReadWriteTransaction() {
+		numRows, err = session.RunUpdate(stmt)
 		if err != nil {
 			// Need to call rollback to free the acquired session in underlying google-cloud-go/spanner.
 			rollback := &RollbackStatement{}
@@ -772,7 +732,7 @@ func (s *DmlStatement) Execute(session *Session) (*Result, error) {
 			return nil, err
 		}
 
-		numRows, err = session.rwTxn.Update(session.ctx, stmt)
+		numRows, err = session.RunUpdate(stmt)
 		if err != nil {
 			// once error has happened, escape from implicit transaction
 			rollback := &RollbackStatement{}
@@ -798,11 +758,11 @@ type PartitionedDmlStatement struct {
 }
 
 func (s *PartitionedDmlStatement) Execute(session *Session) (*Result, error) {
-	if session.InRwTxn() {
+	if session.InReadWriteTransaction() {
 		// PartitionedUpdate creates a new transaction and it could cause dead lock with the current running transaction.
 		return nil, errors.New(`Partitioned DML statement can not be run in a read-write transaction`)
 	}
-	if session.InRoTxn() {
+	if session.InReadOnlyTransaction() {
 		// Just for user-friendly.
 		return nil, errors.New(`Partitioned DML statement can not be run in a read-only transaction`)
 	}
@@ -825,7 +785,7 @@ type ExplainDmlStatement struct {
 
 func (s *ExplainDmlStatement) Execute(session *Session) (*Result, error) {
 	_, timestamp, queryPlan, err := runInNewOrExistRwTxForExplain(session, func() (int64, *pb.QueryPlan, error) {
-		plan, err := session.rwTxn.AnalyzeQuery(session.ctx, spanner.NewStatement(s.Dml))
+		plan, err := session.RunAnalyzeQuery(spanner.NewStatement(s.Dml))
 		return 0, plan, err
 	})
 	if err != nil {
@@ -856,7 +816,7 @@ func (s *ExplainAnalyzeDmlStatement) Execute(session *Session) (*Result, error) 
 	stmt := spanner.NewStatement(s.Dml)
 
 	affectedRows, timestamp, queryPlan, err := runInNewOrExistRwTxForExplain(session, func() (int64, *pb.QueryPlan, error) {
-		iter := session.rwTxn.QueryWithStats(session.ctx, stmt)
+		iter, _ := session.RunQueryWithStats(stmt)
 		defer iter.Stop()
 		err := iter.Do(func(r *spanner.Row) error { return nil })
 		if err != nil {
@@ -888,7 +848,7 @@ func (s *ExplainAnalyzeDmlStatement) Execute(session *Session) (*Result, error) 
 // runInNewOrExistRwTxForExplain is a helper function for ExplainDmlStatement and ExplainAnalyzeDmlStatement.
 // It execute a function in the current RW transaction or an implicit RW transaction.
 func runInNewOrExistRwTxForExplain(session *Session, f func() (affected int64, plan *pb.QueryPlan, err error)) (affected int64, ts time.Time, plan *pb.QueryPlan, err error) {
-	if session.InRwTxn() {
+	if session.InReadWriteTransaction() {
 		affected, plan, err := f()
 		if err != nil {
 			// Need to call rollback to free the acquired session in underlying google-cloud-go/spanner.
@@ -924,19 +884,16 @@ func runInNewOrExistRwTxForExplain(session *Session, f func() (affected int64, p
 type BeginRwStatement struct{}
 
 func (s *BeginRwStatement) Execute(session *Session) (*Result, error) {
-	if session.InRwTxn() {
+	if session.InReadWriteTransaction() {
 		return nil, errors.New("you're in read-write transaction. Please finish the transaction by 'COMMIT;' or 'ROLLBACK;'")
 	}
-	if session.InRoTxn() {
+	if session.InReadOnlyTransaction() {
 		return nil, errors.New("you're in read-only transaction. Please finish the transaction by 'CLOSE;'")
 	}
 
-	txn, err := spanner.NewReadWriteStmtBasedTransaction(session.ctx, session.client)
-	if err != nil {
+	if err := session.BeginReadWriteTransaction(); err != nil {
 		return nil, err
 	}
-	session.StartRwTxn(txn)
-	session.StartHeartbeat()
 
 	return &Result{IsMutation: true}, nil
 }
@@ -945,24 +902,19 @@ type CommitStatement struct{}
 
 func (s *CommitStatement) Execute(session *Session) (*Result, error) {
 	result := &Result{IsMutation: true}
-	if session.InRoTxn() {
+	if session.InReadOnlyTransaction() {
 		return nil, errors.New("you're in read-only transaction. Please finish the transaction by 'CLOSE;'")
 	}
-	if !session.InRwTxn() {
+	if !session.InReadWriteTransaction() {
 		return result, nil
 	}
 
-	// Stop heartbeat before calling commit
-	// because once commit has finished there is no guarantee that transaction object can be used.
-	session.StopHeartbeat()
-
-	ts, err := session.rwTxn.Commit(session.ctx)
-	session.FinishRwTxn()
+	ts, err := session.CommitReadWriteTransaction()
 	if err != nil {
 		return nil, err
 	}
-	result.Timestamp = ts
 
+	result.Timestamp = ts
 	return result, nil
 }
 
@@ -970,19 +922,14 @@ type RollbackStatement struct{}
 
 func (s *RollbackStatement) Execute(session *Session) (*Result, error) {
 	result := &Result{IsMutation: true}
-	if session.InRoTxn() {
+	if session.InReadOnlyTransaction() {
 		return nil, errors.New("you're in read-only transaction. Please finish the transaction by 'CLOSE;'")
 	}
-	if !session.InRwTxn() {
+	if !session.InReadWriteTransaction() {
 		return result, nil
 	}
 
-	// Stop heartbeat before calling rollback
-	// because once rollback has finished there is no guarantee that transaction object can be used.
-	session.StopHeartbeat()
-
-	session.rwTxn.Rollback(session.ctx)
-	session.FinishRwTxn()
+	session.RollbackReadWriteTransaction()
 
 	return result, nil
 }
@@ -1024,55 +971,40 @@ func newBeginRoStatement(input string) *BeginRoStatement {
 }
 
 func (s *BeginRoStatement) Execute(session *Session) (*Result, error) {
-	if session.InRwTxn() {
+	if session.InReadWriteTransaction() {
 		return nil, errors.New("You're in read-write transaction. Please finish the transaction by 'COMMIT;' or 'ROLLBACK;'")
 	}
-	if session.InRoTxn() {
+	if session.InReadOnlyTransaction() {
 		// close current transaction implicitly
 		close := &CloseStatement{}
 		close.Execute(session)
 	}
 
-	txn := session.client.ReadOnlyTransaction()
-	switch s.TimestampBoundType {
-	case strong:
-		txn = txn.WithTimestampBound(spanner.StrongRead())
-	case exactStaleness:
-		txn = txn.WithTimestampBound(spanner.ExactStaleness(s.Staleness))
-	case readTimestamp:
-		txn = txn.WithTimestampBound(spanner.ReadTimestamp(s.Timestamp))
+	ts, err := session.BeginReadOnlyTransaction(s.TimestampBoundType, s.Staleness, s.Timestamp)
+	if err != nil {
+		return nil, err
 	}
-	session.StartRoTxn(txn)
 
 	return &Result{
 		IsMutation: true,
-		Timestamp:  determineReadTimestamp(session.ctx, txn),
+		Timestamp:  ts,
 	}, nil
-}
-
-// determineReadTimestamp ensures BeginTransaction RPC is called
-// and returns the read timestamp of the read only transaction
-func determineReadTimestamp(ctx context.Context, txn *spanner.ReadOnlyTransaction) time.Time {
-	iter := txn.Query(ctx, spanner.NewStatement("SELECT 1"))
-	defer iter.Stop()
-	ts, _ := txn.Timestamp()
-	return ts
 }
 
 type CloseStatement struct{}
 
 func (s *CloseStatement) Execute(session *Session) (*Result, error) {
-	if session.InRwTxn() {
+	if session.InReadWriteTransaction() {
 		return nil, errors.New("You're in read-write transaction. Please finish the transaction by 'COMMIT;' or 'ROLLBACK;'")
 	}
 
 	result := &Result{IsMutation: true}
 
-	if !session.InRoTxn() {
+	if !session.InReadOnlyTransaction() {
 		return result, nil
 	}
 
-	session.FinishRoTxn()
+	session.CloseReadOnlyTransaction()
 
 	return result, nil
 }


### PR DESCRIPTION
# Overview

Transaction heartbeat is deferred to the time when a user executes a SQL statement on the transaction. This ensures that a user-initiated query is the first query after `BeginTransaction` is called. See https://github.com/cloudspannerecosystem/spanner-cli/issues/100 for more details.

This PR also contains the refactoring of transaction handling. I have moved the logic of transaction state from `statement.go` to `session.go` to handle the state in one place.

## Example
This is the actual RPCs called when I executed the following commands in spanner-cli.

```
BEGIN;
SELECT * FROM Accounts WHERE UserId = 1;
UPDATE Accounts SET Balance = 4000 WHERE UserId = 1;
COMMIT
```

(Note: order by timestamp DESC)
![image](https://user-images.githubusercontent.com/1595215/102748053-d3150600-43a4-11eb-8bb9-702ce8457f18.png)

close: https://github.com/cloudspannerecosystem/spanner-cli/issues/100