### PR TITLE
Show deleted_rows_scanned stats in verbose mode

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -420,7 +420,7 @@ func resultLine(result *Result, verbose bool) string {
 	}
 
 	if verbose {
-		// detail is aligned with max length of key (current: 9)
+		// detail is aligned with max length of key (current: 20)
 		var detail string
 		if timestamp != "" {
 			detail += fmt.Sprintf("timestamp:            %s\n", timestamp)

--- a/cli.go
+++ b/cli.go
@@ -423,16 +423,19 @@ func resultLine(result *Result, verbose bool) string {
 		// detail is aligned with max length of key (current: 9)
 		var detail string
 		if timestamp != "" {
-			detail += fmt.Sprintf("timestamp: %s\n", timestamp)
+			detail += fmt.Sprintf("timestamp:            %s\n", timestamp)
 		}
 		if result.Stats.CPUTime != "" {
-			detail += fmt.Sprintf("cpu:       %s\n", result.Stats.CPUTime)
+			detail += fmt.Sprintf("cpu time:             %s\n", result.Stats.CPUTime)
 		}
 		if result.Stats.RowsScanned != "" {
-			detail += fmt.Sprintf("scanned:   %s rows\n", result.Stats.RowsScanned)
+			detail += fmt.Sprintf("rows scanned:         %s rows\n", result.Stats.RowsScanned)
+		}
+		if result.Stats.DeletedRowsScanned != "" {
+			detail += fmt.Sprintf("deleted rows scanned: %s rows\n", result.Stats.DeletedRowsScanned)
 		}
 		if result.Stats.OptimizerVersion != "" {
-			detail += fmt.Sprintf("optimizer: %s\n", result.Stats.OptimizerVersion)
+			detail += fmt.Sprintf("optimizer version:    %s\n", result.Stats.OptimizerVersion)
 		}
 		return fmt.Sprintf("%s (%s)\n%s", set, result.Stats.ElapsedTime, detail)
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -318,20 +318,22 @@ func TestResultLine(t *testing.T) {
 				AffectedRows: 3,
 				IsMutation:   false,
 				Stats: QueryStats{
-					ElapsedTime:      "10 msec",
-					CPUTime:          "5 msec",
-					RowsScanned:      "10",
-					RowsReturned:     "3",
-					OptimizerVersion: "2",
+					ElapsedTime:        "10 msec",
+					CPUTime:            "5 msec",
+					RowsScanned:        "10",
+					RowsReturned:       "3",
+					DeletedRowsScanned: "1",
+					OptimizerVersion:   "2",
 				},
 				Timestamp: ts,
 			},
 			verbose: true,
 			want: fmt.Sprintf(`3 rows in set (10 msec)
-timestamp: %s
-cpu:       5 msec
-scanned:   10 rows
-optimizer: 2
+timestamp:            %s
+cpu time:             5 msec
+rows scanned:         10 rows
+deleted rows scanned: 1 rows
+optimizer version:    2
 `, timestamp),
 		},
 		{
@@ -346,7 +348,7 @@ optimizer: 2
 				Timestamp: ts,
 			},
 			verbose: true,
-			want:    fmt.Sprintf("3 rows in set (10 msec)\ntimestamp: %s\n", timestamp),
+			want:    fmt.Sprintf("3 rows in set (10 msec)\ntimestamp:            %s\n", timestamp),
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/statement.go
+++ b/statement.go
@@ -71,11 +71,12 @@ type Row struct {
 // Some fields may not have a valid value depending on the environment.
 // For example, only ElapsedTime and RowsReturned has valid value for Cloud Spanner Emulator.
 type QueryStats struct {
-	ElapsedTime      string
-	CPUTime          string
-	RowsReturned     string
-	RowsScanned      string
-	OptimizerVersion string
+	ElapsedTime        string
+	CPUTime            string
+	RowsReturned       string
+	RowsScanned        string
+	DeletedRowsScanned string
+	OptimizerVersion   string
 }
 
 var (
@@ -292,6 +293,12 @@ func parseQueryStats(stats map[string]interface{}) QueryStats {
 	if v, ok := stats["rows_scanned"]; ok {
 		if scanned, ok := v.(string); ok {
 			queryStats.RowsScanned = scanned
+		}
+	}
+
+	if v, ok := stats["deleted_rows_scanned"]; ok {
+		if deletedRowsScanned, ok := v.(string); ok {
+			queryStats.DeletedRowsScanned = deletedRowsScanned
 		}
 	}
 


### PR DESCRIPTION
The `deleted_rows_scanned` in QueryStats is usuful for diagnosing bottlenecks in scanned tables with many insertion and deletion.   

I added `deleted rows scanned` section in verbose mode.

### Before 
```
spanner> select count(*) from new_orders;
+--------+
|        |
+--------+
| 835790 |
+--------+
1 rows in set (70.49 msecs)
timestamp: 2021-03-09T14:04:10.376489+09:00
cpu:       325.3 msecs
scanned:   835790 rows
optimizer: 2
```

### After
```
spanner> select count(*) from new_orders;
+--------+
|        |
+--------+
| 835790 |
+--------+
1 rows in set (70.49 msecs)
timestamp:            2021-03-09T14:04:10.376489+09:00
cpu time:             325.3 msecs
rows scanned:         835790 rows
deleted rows scanned: 232750 rows
optimizer version:    2
```