### PR TITLE
Support ALTER DATABASE statement

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -86,6 +86,7 @@ var (
 	// DDL
 	createDatabaseRe = regexp.MustCompile(`(?is)^CREATE\s+DATABASE\s.+$`)
 	dropDatabaseRe   = regexp.MustCompile(`(?is)^DROP\s+DATABASE\s+(.+)$`)
+	alterDatabaseRe  = regexp.MustCompile(`(?is)^ALTER\s+DATABASE\s.+$`)
 	createTableRe    = regexp.MustCompile(`(?is)^CREATE\s+TABLE\s.+$`)
 	alterTableRe     = regexp.MustCompile(`(?is)^ALTER\s+TABLE\s.+$`)
 	dropTableRe      = regexp.MustCompile(`(?is)^DROP\s+TABLE\s.+$`)
@@ -138,6 +139,8 @@ func BuildStatement(input string) (Statement, error) {
 	case dropDatabaseRe.MatchString(input):
 		matched := dropDatabaseRe.FindStringSubmatch(input)
 		return &DropDatabaseStatement{DatabaseId: unquoteIdentifier(matched[1])}, nil
+	case alterDatabaseRe.MatchString(input):
+		return &DdlStatement{Ddl: input}, nil
 	case createTableRe.MatchString(input):
 		return &DdlStatement{Ddl: input}, nil
 	case alterTableRe.MatchString(input):

--- a/statement_test.go
+++ b/statement_test.go
@@ -77,6 +77,11 @@ func TestBuildStatement(t *testing.T) {
 			want:  &DropDatabaseStatement{DatabaseId: "TABLE"},
 		},
 		{
+			desc:  "ALTER DATABASE statement",
+			input: "ALTER DATABASE d1 SET OPTIONS ( version_retention_period = '7d' )",
+			want:  &DdlStatement{Ddl: "ALTER DATABASE d1 SET OPTIONS ( version_retention_period = '7d' )"},
+		},
+		{
 			desc:  "CREATE TABLE statement",
 			input: "CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY (id)",
 			want:  &DdlStatement{Ddl: "CREATE TABLE t1 (id INT64 NOT NULL) PRIMARY KEY (id)"},


### PR DESCRIPTION
Fix https://github.com/cloudspannerecosystem/spanner-cli/issues/115.

[ALTER DATABASE](https://cloud.google.com/spanner/docs/data-definition-language#alter-database) statement is a part of DDL and it can be updated by [UpdateDatabaseDdl](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.DatabaseAdmin.UpdateDatabaseDdl) RPC.