### PR TITLE
Support VIEW statements

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -84,15 +84,18 @@ var (
 	selectRe = regexp.MustCompile(`(?is)^(?:WITH|@{.+|SELECT)\s.+$`)
 
 	// DDL
-	createDatabaseRe = regexp.MustCompile(`(?is)^CREATE\s+DATABASE\s.+$`)
-	dropDatabaseRe   = regexp.MustCompile(`(?is)^DROP\s+DATABASE\s+(.+)$`)
-	alterDatabaseRe  = regexp.MustCompile(`(?is)^ALTER\s+DATABASE\s.+$`)
-	createTableRe    = regexp.MustCompile(`(?is)^CREATE\s+TABLE\s.+$`)
-	alterTableRe     = regexp.MustCompile(`(?is)^ALTER\s+TABLE\s.+$`)
-	dropTableRe      = regexp.MustCompile(`(?is)^DROP\s+TABLE\s.+$`)
-	createIndexRe    = regexp.MustCompile(`(?is)^CREATE\s+(UNIQUE\s+)?(NULL_FILTERED\s+)?INDEX\s.+$`)
-	dropIndexRe      = regexp.MustCompile(`(?is)^DROP\s+INDEX\s.+$`)
-	truncateTableRe  = regexp.MustCompile(`(?is)^TRUNCATE\s+TABLE\s+(.+)$`)
+	createDatabaseRe      = regexp.MustCompile(`(?is)^CREATE\s+DATABASE\s.+$`)
+	dropDatabaseRe        = regexp.MustCompile(`(?is)^DROP\s+DATABASE\s+(.+)$`)
+	alterDatabaseRe       = regexp.MustCompile(`(?is)^ALTER\s+DATABASE\s.+$`)
+	createTableRe         = regexp.MustCompile(`(?is)^CREATE\s+TABLE\s.+$`)
+	alterTableRe          = regexp.MustCompile(`(?is)^ALTER\s+TABLE\s.+$`)
+	dropTableRe           = regexp.MustCompile(`(?is)^DROP\s+TABLE\s.+$`)
+	createIndexRe         = regexp.MustCompile(`(?is)^CREATE\s+(UNIQUE\s+)?(NULL_FILTERED\s+)?INDEX\s.+$`)
+	dropIndexRe           = regexp.MustCompile(`(?is)^DROP\s+INDEX\s.+$`)
+	truncateTableRe       = regexp.MustCompile(`(?is)^TRUNCATE\s+TABLE\s+(.+)$`)
+	createViewRe          = regexp.MustCompile(`(?is)^CREATE\s+VIEW\s.+$`)
+	createOrReplaceViewRe = regexp.MustCompile(`(?is)^CREATE\s+OR\s+REPLACE\s+VIEW\s.+$`)
+	dropViewRe            = regexp.MustCompile(`(?is)^DROP\s+VIEW\s.+$`)
 
 	// DML
 	dmlRe = regexp.MustCompile(`(?is)^(INSERT|UPDATE|DELETE)\s+.+$`)
@@ -154,6 +157,8 @@ func BuildStatement(input string) (Statement, error) {
 	case truncateTableRe.MatchString(input):
 		matched := truncateTableRe.FindStringSubmatch(input)
 		return &TruncateTableStatement{Table: unquoteIdentifier(matched[1])}, nil
+	case createViewRe.MatchString(input), createOrReplaceViewRe.MatchString(input), dropViewRe.MatchString(input):
+		return &DdlStatement{Ddl: input}, nil
 	case showDatabasesRe.MatchString(input):
 		return &ShowDatabasesStatement{}, nil
 	case showCreateTableRe.MatchString(input):

--- a/statement_test.go
+++ b/statement_test.go
@@ -112,6 +112,21 @@ func TestBuildStatement(t *testing.T) {
 			want:  &TruncateTableStatement{Table: "t1"},
 		},
 		{
+			desc:  "CREATE VIEW statement",
+			input: "CREATE VIEW t1view SQL SECURITY INVOKER AS SELECT t1.Id FROM t1",
+			want:  &DdlStatement{Ddl: "CREATE VIEW t1view SQL SECURITY INVOKER AS SELECT t1.Id FROM t1"},
+		},
+		{
+			desc:  "CREATE OR REPLACE VIEW statement",
+			input: "CREATE OR REPLACE VIEW t1view SQL SECURITY INVOKER AS SELECT t1.Id FROM t1",
+			want:  &DdlStatement{Ddl: "CREATE OR REPLACE VIEW t1view SQL SECURITY INVOKER AS SELECT t1.Id FROM t1"},
+		},
+		{
+			desc:  "DROP VIEW statement",
+			input: "DROP VIEW t1view",
+			want:  &DdlStatement{Ddl: "DROP VIEW t1view"},
+		},
+		{
 			desc:  "INSERT statement",
 			input: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')",
 			want:  &DmlStatement{Dml: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')"},


### PR DESCRIPTION
This PR supports the following three [VIEW](https://cloud.google.com/spanner/docs/views) statements.

1. Create View: `CREATE VIEW ...;`
2. Update View: `CREATE OR REPLACE VIEW ...;`
3. Delete View: `DROP VIEW ...;`

Example:

```
spanner> CREATE TABLE Singers (
      ->   SingerId   INT64 NOT NULL,
      ->   FirstName  STRING(1024),
      ->   LastName   STRING(1024),
      ->   SingerInfo BYTES(MAX),
      -> ) PRIMARY KEY (SingerId);
Query OK, 0 rows affected (4.16 sec)

spanner> INSERT INTO Singers (SingerId, FirstName, LastName) VALUES (1, "foo", "bar");
Query OK, 1 rows affected (0.58 sec)

spanner> CREATE VIEW SingerNames
      -> SQL SECURITY INVOKER
      -> AS SELECT
      ->   Singers.SingerId AS SingerId,
      ->   Singers.FirstName || " " || Singers.LastName AS Name
      -> FROM Singers;
Query OK, 0 rows affected (4.42 sec)

spanner> SELECT * FROM SingerNames;
+----------+---------+
| SingerId | Name    |
+----------+---------+
| 1        | foo bar |
+----------+---------+
1 rows in set (9.07 msecs)

spanner> CREATE OR REPLACE VIEW SingerNames
      -> SQL SECURITY INVOKER
      -> AS SELECT
      ->   Singers.SingerId AS SingerId,
      ->   UPPER(Singers.FirstName) || " " || UPPER(Singers.LastName) AS Name
      -> FROM Singers;
Query OK, 0 rows affected (7.12 sec)

spanner> SELECT * FROM SingerNames;
+----------+---------+
| SingerId | Name    |
+----------+---------+
| 1        | FOO BAR |
+----------+---------+
1 rows in set (18.73 msecs)

spanner> DROP VIEW SingerNames;
Query OK, 0 rows affected (4.79 sec)
```