### PR TITLE
Support optimizer statistics

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -440,6 +440,9 @@ func resultLine(result *Result, verbose bool) string {
 		if result.Stats.OptimizerVersion != "" {
 			detail += fmt.Sprintf("optimizer version:    %s\n", result.Stats.OptimizerVersion)
 		}
+		if result.Stats.OptimizerStatisticsPackage != "" {
+			detail += fmt.Sprintf("optimizer statistics: %s\n", result.Stats.OptimizerStatisticsPackage)
+		}
 		return fmt.Sprintf("%s (%s)\n%s", set, result.Stats.ElapsedTime, detail)
 	}
 	return fmt.Sprintf("%s (%s)\n", set, result.Stats.ElapsedTime)

--- a/cli_test.go
+++ b/cli_test.go
@@ -318,12 +318,13 @@ func TestResultLine(t *testing.T) {
 				AffectedRows: 3,
 				IsMutation:   false,
 				Stats: QueryStats{
-					ElapsedTime:        "10 msec",
-					CPUTime:            "5 msec",
-					RowsScanned:        "10",
-					RowsReturned:       "3",
-					DeletedRowsScanned: "1",
-					OptimizerVersion:   "2",
+					ElapsedTime:                "10 msec",
+					CPUTime:                    "5 msec",
+					RowsScanned:                "10",
+					RowsReturned:               "3",
+					DeletedRowsScanned:         "1",
+					OptimizerVersion:           "2",
+					OptimizerStatisticsPackage: "auto_20210829_05_22_28UTC",
 				},
 				Timestamp: ts,
 			},
@@ -334,6 +335,7 @@ cpu time:             5 msec
 rows scanned:         10 rows
 deleted rows scanned: 1 rows
 optimizer version:    2
+optimizer statistics: auto_20210829_05_22_28UTC
 `, timestamp),
 		},
 		{

--- a/statement_test.go
+++ b/statement_test.go
@@ -127,6 +127,11 @@ func TestBuildStatement(t *testing.T) {
 			want:  &DdlStatement{Ddl: "DROP VIEW t1view"},
 		},
 		{
+			desc:  "ALTER STATISTICS statement",
+			input: "ALTER STATISTICS package SET OPTIONS (allow_gc = false)",
+			want:  &DdlStatement{Ddl: "ALTER STATISTICS package SET OPTIONS (allow_gc = false)"},
+		},
+		{
 			desc:  "INSERT statement",
 			input: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')",
 			want:  &DmlStatement{Dml: "INSERT INTO t1 (id, name) VALUES (1, 'yuki')"},


### PR DESCRIPTION
This PR has two changes to support [optimizer statistics](https://cloud.google.com/spanner/docs/query-optimizer/overview#query_optimizer_statistics_packages):

1. Support `ALTER STATISTICS` statement.
2. Show optimizer statistics package name in verbose mode.

Example:

```
spanner> ALTER STATISTICS auto_20210829_05_22_28UTC SET OPTIONS (allow_gc = false);
Query OK, 0 rows affected (40.93 sec)

spanner> SELECT * FROM Singers;
+----------+-----------+----------+------------+------------+
| SingerId | FirstName | LastName | SingerInfo | BirthDate  |
+----------+-----------+----------+------------+------------+
| 1        | b         | Richards | NULL       | 1970-09-03 |
| 2        | Catalina  | Smith    | NULL       | 1990-08-17 |
| 3        | Alice     | Trentor  | NULL       | 1991-10-02 |
| 4        | Lea       | Martin   | NULL       | 1991-11-09 |
| 5        | David     | Lomond   | NULL       | 1977-01-29 |
+----------+-----------+----------+------------+------------+
5 rows in set (2.75 msecs)
timestamp:            2021-08-31T13:58:59.509876+09:00
cpu time:             0.9 msecs
rows scanned:         5 rows
deleted rows scanned: 0 rows
optimizer version:    2
optimizer statistics: auto_20210829_05_22_28UTC
```