### PR TITLE
Fix from base64.RawStdEncoding to base64.StdEncoding

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -235,7 +235,7 @@ func nullBoolToString(v spanner.NullBool) string {
 
 func nullBytesToString(v []byte) string {
 	if v != nil {
-		return base64.RawStdEncoding.EncodeToString(v)
+		return base64.StdEncoding.EncodeToString(v)
 	} else {
 		return "NULL"
 	}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -86,8 +86,8 @@ func TestDecodeColumn(t *testing.T) {
 		},
 		{
 			desc:  "bytes",
-			value: []byte{'a', 'b', 'c'},
-			want:  "YWJj", // base64 encoded 'abc'
+			value: []byte{'a', 'b', 'c', 'd'},
+			want:  "YWJjZA==", // base64 encoded 'abc'
 		},
 		{
 			desc:  "float64",
@@ -190,8 +190,8 @@ func TestDecodeColumn(t *testing.T) {
 		},
 		{
 			desc:  "array bytes",
-			value: [][]byte{{'a', 'b', 'c'}, {'e', 'f', 'g'}},
-			want:  "[YWJj, ZWZn]",
+			value: [][]byte{{'a', 'b', 'c', 'd'}, {'e', 'f', 'g', 'h'}},
+			want:  "[YWJjZA==, ZWZnaA==]",
 		},
 		{
 			desc:  "array float64",


### PR DESCRIPTION
It seems that the BYTES type in Cloud Spanner needs to be encoded as base64 with padding.

https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/type.proto#L116-L118
https://github.com/googleapis/google-cloud-go/blob/7eaaa470fda5dc7cd1ff041d6a898e35fb54920e/spanner/value.go#L1085

Currently, spanner-cli uses base64.RawStdEncoding, but the padding is missing when outputting the data.

## Example of tests

![スクリーンショット 2022-01-25 10 06 57](https://user-images.githubusercontent.com/2740807/150892019-7d5cbb0c-5db8-4f48-bb99-80b3271ab563.png)

![スクリーンショット 2022-01-25 10 06 46](https://user-images.githubusercontent.com/2740807/150892032-4d00d849-0c9b-4bc4-816f-5d02e18535c7.png)

### Currently

```console
$ spanner-cli -p <my-project> -i <my-instance> -d <my-db> -e 'SELECT id, bytes FROM TestTable'
id      bytes
1       aGVsbG8sIHdvcmxkIQ
```

### Fixed

```console
$ spanner-cli -p <my-project> -i <my-instance> -d <my-db> -e 'SELECT id, bytes FROM TestTable'
id      bytes
1       aGVsbG8sIHdvcmxkIQ==
```