### PR TITLE
Support Transaction Tags and Request Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ and `{}` for a mutually exclusive keyword.
 | Show DML Execution Plan | `EXPLAIN {INSERT\|UPDATE\|DELETE} ...;` | |
 | Show Query Execution Plan with Stats | `EXPLAIN ANALYZE SELECT ...;` | |
 | Show DML Execution Plan with Stats | `EXPLAIN ANALYZE {INSERT\|UPDATE\|DELETE} ...;` | |
-| Start Read-Write Transaction | `BEGIN [RW] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <tags>];` | See [Request Priority](#request-priority) for details on the priority. The tags you set are used as transaction tags and request tags. See also [Transaction Tags and Request Tags](#transaction-tags-and-request-tags).|
+| Start Read-Write Transaction | `BEGIN [RW] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <tag>];` | See [Request Priority](#request-priority) for details on the priority. The tag you set is used as both transaction tag and request tag. See also [Transaction Tags and Request Tags](#transaction-tags-and-request-tags).|
 | Commit Read-Write Transaction | `COMMIT;` | |
 | Rollback Read-Write Transaction | `ROLLBACK;` | |
-| Start Read-Only Transaction | `BEGIN RO [{<seconds>\|<RFC3339-formatted time>}] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <tags>];` | `<seconds>` and `<RFC3339-formatted time>` is used for stale read. See [Request Priority](#request-priority) for details on the priority. The tags you set are used as request tags. See also [Transaction Tags and Request Tags](#transaction-tags-and-request-tags).|
+| Start Read-Only Transaction | `BEGIN RO [{<seconds>\|<RFC3339-formatted time>}] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <tag>];` | `<seconds>` and `<RFC3339-formatted time>` is used for stale read. See [Request Priority](#request-priority) for details on the priority. The tag you set is used as request tag. See also [Transaction Tags and Request Tags](#transaction-tags-and-request-tags).|
 | End Read-Only Transaction | `CLOSE;` | |
 | Exit CLI | `EXIT;` | |
 
@@ -261,9 +261,9 @@ Note that transaction-level priority takes precedence over command-level priorit
 
 ## Transaction Tags and Request Tags
 
-In a read-write transaction, you can add arbitrary tags following `BEGIN RW TAG <tags>`.
-spanner-cli adds the tags set in `BEGIN RW TAG` as transaction tags.
-This tag will also be used as request tags within that transaction.
+In a read-write transaction, you can add a tag following `BEGIN RW TAG <tag>`.
+spanner-cli adds the tag set in `BEGIN RW TAG` as a transaction tag.
+The tag will also be used as request tags within the transaction.
 
 ```
 # Read-write transaction
@@ -283,8 +283,8 @@ This tag will also be used as request tags within that transaction.
 +--------------------+
 ```
 
-In a read-only transaction, you can add arbitrary tags following `BEGIN RO TAG <tags>`.
-Since read-only transaction doesn't support transaction tags, spanner-cli adds the tag set in `BEGIN RO TAG` as request tags.
+In a read-only transaction, you can add a tag following `BEGIN RO TAG <tag>`.
+Since read-only transaction doesn't support transaction tag, spanner-cli adds the tag set in `BEGIN RO TAG` as request tags.
 ```
 # Read-only transaction
 # transaction_tag = N/A

--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ and `{}` for a mutually exclusive keyword.
 | Show DML Execution Plan | `EXPLAIN {INSERT\|UPDATE\|DELETE} ...;` | |
 | Show Query Execution Plan with Stats | `EXPLAIN ANALYZE SELECT ...;` | |
 | Show DML Execution Plan with Stats | `EXPLAIN ANALYZE {INSERT\|UPDATE\|DELETE} ...;` | |
-| Start Read-Write Transaction | `BEGIN [RW] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <transaction_tags>];` | See [Request Priority](#request-priority) for details on the priority. You can add [transaction tags](https://cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags#transaction_tags?hl=en).|
+| Start Read-Write Transaction | `BEGIN [RW] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <transaction_tags>];` | See [Request Priority](#request-priority) for details on the priority. You can add [transaction tags](https://cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags#transaction_tags?hl=en). The transaction tags are also used as [request tags](https://cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags#request_tags?hl=en) in the transaction.|
 | Commit Read-Write Transaction | `COMMIT;` | |
 | Rollback Read-Write Transaction | `ROLLBACK;` | |
-| Start Read-Only Transaction | `BEGIN RO [{<seconds>\|<RFC3339-formatted time>}] [PRIORITY {HIGH\|MEDIUM\|LOW}];` | `<seconds>` and `<RFC3339-formatted time>` is used for stale read. See [Request Priority](#request-priority) for details on the priority. |
+| Start Read-Only Transaction | `BEGIN RO [{<seconds>\|<RFC3339-formatted time>}] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <request_tags>];` | `<seconds>` and `<RFC3339-formatted time>` is used for stale read. See [Request Priority](#request-priority) for details on the priority. You can add [request tags](https://cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags#request_tags?hl=en).|
 | End Read-Only Transaction | `CLOSE;` | |
 | Exit CLI | `EXIT;` | |
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ and `{}` for a mutually exclusive keyword.
 | Show DML Execution Plan | `EXPLAIN {INSERT\|UPDATE\|DELETE} ...;` | |
 | Show Query Execution Plan with Stats | `EXPLAIN ANALYZE SELECT ...;` | |
 | Show DML Execution Plan with Stats | `EXPLAIN ANALYZE {INSERT\|UPDATE\|DELETE} ...;` | |
-| Start Read-Write Transaction | `BEGIN [RW] [PRIORITY {HIGH\|MEDIUM\|LOW}];` | See [Request Priority](#request-priority) for details on the priority. |
+| Start Read-Write Transaction | `BEGIN [RW] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <transaction_tags>];` | See [Request Priority](#request-priority) for details on the priority. You can add [transaction tags](https://cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags#transaction_tags?hl=en).|
 | Commit Read-Write Transaction | `COMMIT;` | |
 | Rollback Read-Write Transaction | `ROLLBACK;` | |
 | Start Read-Only Transaction | `BEGIN RO [{<seconds>\|<RFC3339-formatted time>}] [PRIORITY {HIGH\|MEDIUM\|LOW}];` | `<seconds>` and `<RFC3339-formatted time>` is used for stale read. See [Request Priority](#request-priority) for details on the priority. |

--- a/session.go
+++ b/session.go
@@ -109,7 +109,7 @@ func (s *Session) InReadOnlyTransaction() bool {
 }
 
 // BeginReadWriteTransaction starts read-write transaction.
-func (s *Session) BeginReadWriteTransaction(priority pb.RequestOptions_Priority) error {
+func (s *Session) BeginReadWriteTransaction(priority pb.RequestOptions_Priority, transactionTag string) error {
 	if s.InReadWriteTransaction() {
 		return errors.New("read-write transaction is already running")
 	}
@@ -122,6 +122,7 @@ func (s *Session) BeginReadWriteTransaction(priority pb.RequestOptions_Priority)
 	opts := spanner.TransactionOptions{
 		CommitOptions:  spanner.CommitOptions{ReturnCommitStats: true},
 		CommitPriority: priority,
+		TransactionTag: transactionTag,
 	}
 	txn, err := spanner.NewReadWriteStmtBasedTransactionWithOptions(s.ctx, s.client, opts)
 	if err != nil {

--- a/session.go
+++ b/session.go
@@ -59,12 +59,11 @@ type Session struct {
 }
 
 type transactionContext struct {
-	requestTag     string
-	transactionTag string
-	priority       pb.RequestOptions_Priority
-	sendHeartbeat  bool // Becomes true only after a user-driven query is executed on the transaction.
-	rwTxn          *spanner.ReadWriteStmtBasedTransaction
-	roTxn          *spanner.ReadOnlyTransaction
+	tag           string
+	priority      pb.RequestOptions_Priority
+	sendHeartbeat bool // Becomes true only after a user-driven query is executed on the transaction.
+	rwTxn         *spanner.ReadWriteStmtBasedTransaction
+	roTxn         *spanner.ReadOnlyTransaction
 }
 
 func NewSession(ctx context.Context, projectId string, instanceId string, databaseId string, priority pb.RequestOptions_Priority, opts ...option.ClientOption) (*Session, error) {
@@ -111,7 +110,7 @@ func (s *Session) InReadOnlyTransaction() bool {
 }
 
 // BeginReadWriteTransaction starts read-write transaction.
-func (s *Session) BeginReadWriteTransaction(priority pb.RequestOptions_Priority, transactionTag string) error {
+func (s *Session) BeginReadWriteTransaction(priority pb.RequestOptions_Priority, tag string) error {
 	if s.InReadWriteTransaction() {
 		return errors.New("read-write transaction is already running")
 	}
@@ -124,16 +123,16 @@ func (s *Session) BeginReadWriteTransaction(priority pb.RequestOptions_Priority,
 	opts := spanner.TransactionOptions{
 		CommitOptions:  spanner.CommitOptions{ReturnCommitStats: true},
 		CommitPriority: priority,
-		TransactionTag: transactionTag,
+		TransactionTag: tag,
 	}
 	txn, err := spanner.NewReadWriteStmtBasedTransactionWithOptions(s.ctx, s.client, opts)
 	if err != nil {
 		return err
 	}
 	s.tc = &transactionContext{
-		transactionTag: transactionTag,
-		priority:       priority,
-		rwTxn:          txn,
+		tag:      tag,
+		priority: priority,
+		rwTxn:    txn,
 	}
 	return nil
 }
@@ -167,7 +166,7 @@ func (s *Session) RollbackReadWriteTransaction() error {
 }
 
 // BeginReadOnlyTransaction starts read-only transaction and returns the snapshot timestamp for the transaction if successful.
-func (s *Session) BeginReadOnlyTransaction(typ timestampBoundType, staleness time.Duration, timestamp time.Time, priority pb.RequestOptions_Priority, requestTag string) (time.Time, error) {
+func (s *Session) BeginReadOnlyTransaction(typ timestampBoundType, staleness time.Duration, timestamp time.Time, priority pb.RequestOptions_Priority, tag string) (time.Time, error) {
 	if s.InReadOnlyTransaction() {
 		return time.Time{}, errors.New("read-only transaction is already running")
 	}
@@ -197,9 +196,9 @@ func (s *Session) BeginReadOnlyTransaction(typ timestampBoundType, staleness tim
 	}
 
 	s.tc = &transactionContext{
-		requestTag: requestTag,
-		priority:   priority,
-		roTxn:      txn,
+		tag:      tag,
+		priority: priority,
+		roTxn:    txn,
 	}
 
 	return txn.Timestamp()
@@ -257,20 +256,13 @@ func (s *Session) RunAnalyzeQuery(stmt spanner.Statement) (*pb.QueryPlan, error)
 
 func (s *Session) runQueryWithOptions(stmt spanner.Statement, opts spanner.QueryOptions) (*spanner.RowIterator, *spanner.ReadOnlyTransaction) {
 	if s.InReadWriteTransaction() {
-		if s.tc.transactionTag != "" {
-			// In a read-write transaction, add transaction tags as request tags.
-			opts.RequestTag = s.tc.transactionTag
-		}
+		opts.RequestTag = s.tc.tag
 		iter := s.tc.rwTxn.QueryWithOptions(s.ctx, stmt, opts)
 		s.tc.sendHeartbeat = true
 		return iter, nil
 	}
 	if s.InReadOnlyTransaction() {
-		if s.tc.requestTag != "" {
-			// Read-only transactions do not support transaction tags,
-			// so add the same request tags within the same read-only transaction instead.
-			opts.RequestTag = s.tc.requestTag
-		}
+		opts.RequestTag = s.tc.tag
 		return s.tc.roTxn.QueryWithOptions(s.ctx, stmt, opts), s.tc.roTxn
 	}
 
@@ -286,11 +278,8 @@ func (s *Session) RunUpdate(stmt spanner.Statement) (int64, error) {
 	}
 
 	opts := spanner.QueryOptions{
-		Priority: s.currentPriority(),
-	}
-	if s.tc.transactionTag != "" {
-		// In a read-write transaction, add transaction tags as request tags.
-		opts.RequestTag = s.tc.transactionTag
+		Priority:   s.currentPriority(),
+		RequestTag: s.tc.tag,
 	}
 	rowCount, err := s.tc.rwTxn.UpdateWithOptions(s.ctx, stmt, opts)
 	s.tc.sendHeartbeat = true

--- a/session_test.go
+++ b/session_test.go
@@ -70,7 +70,7 @@ func TestRequestPriority(t *testing.T) {
 			}
 
 			// Read-Write Transaction.
-			if err := session.BeginReadWriteTransaction(test.transactionPriority); err != nil {
+			if err := session.BeginReadWriteTransaction(test.transactionPriority, "app=concert,env=dev"); err != nil {
 				t.Fatalf("failed to begin read write transaction: %v", err)
 			}
 			iter, _ := session.RunQuery(spanner.NewStatement("SELECT * FROM t1"))

--- a/session_test.go
+++ b/session_test.go
@@ -70,7 +70,7 @@ func TestRequestPriority(t *testing.T) {
 			}
 
 			// Read-Write Transaction.
-			if err := session.BeginReadWriteTransaction(test.transactionPriority, "app=concert,env=dev"); err != nil {
+			if err := session.BeginReadWriteTransaction(test.transactionPriority, "app=spanner-cli,env=test"); err != nil {
 				t.Fatalf("failed to begin read write transaction: %v", err)
 			}
 			iter, _ := session.RunQuery(spanner.NewStatement("SELECT * FROM t1"))
@@ -87,7 +87,7 @@ func TestRequestPriority(t *testing.T) {
 			}
 
 			// Read-Only Transaction.
-			if _, err := session.BeginReadOnlyTransaction(strong, 0, time.Now(), test.transactionPriority); err != nil {
+			if _, err := session.BeginReadOnlyTransaction(strong, 0, time.Now(), test.transactionPriority, "app=spanner-cli,env=test"); err != nil {
 				t.Fatalf("failed to begin read only transaction: %v", err)
 			}
 			iter, _ = session.RunQueryWithStats(spanner.NewStatement("SELECT * FROM t1"))

--- a/session_test.go
+++ b/session_test.go
@@ -70,7 +70,7 @@ func TestRequestPriority(t *testing.T) {
 			}
 
 			// Read-Write Transaction.
-			if err := session.BeginReadWriteTransaction(test.transactionPriority, "app=spanner-cli,env=test"); err != nil {
+			if err := session.BeginReadWriteTransaction(test.transactionPriority, ""); err != nil {
 				t.Fatalf("failed to begin read write transaction: %v", err)
 			}
 			iter, _ := session.RunQuery(spanner.NewStatement("SELECT * FROM t1"))
@@ -87,7 +87,7 @@ func TestRequestPriority(t *testing.T) {
 			}
 
 			// Read-Only Transaction.
-			if _, err := session.BeginReadOnlyTransaction(strong, 0, time.Now(), test.transactionPriority, "app=spanner-cli,env=test"); err != nil {
+			if _, err := session.BeginReadOnlyTransaction(strong, 0, time.Now(), test.transactionPriority, ""); err != nil {
 				t.Fatalf("failed to begin read only transaction: %v", err)
 			}
 			iter, _ = session.RunQueryWithStats(spanner.NewStatement("SELECT * FROM t1"))

--- a/statement.go
+++ b/statement.go
@@ -918,8 +918,8 @@ func runInNewOrExistRwTxForExplain(session *Session, f func() (affected int64, p
 }
 
 type BeginRwStatement struct {
-	Priority       pb.RequestOptions_Priority
-	TransactionTag string
+	Priority pb.RequestOptions_Priority
+	Tag      string
 }
 
 func newBeginRwStatement(input string) (*BeginRwStatement, error) {
@@ -935,7 +935,7 @@ func newBeginRwStatement(input string) (*BeginRwStatement, error) {
 	}
 
 	if matched[2] != "" {
-		stmt.TransactionTag = matched[2]
+		stmt.Tag = matched[2]
 	}
 
 	return stmt, nil
@@ -949,7 +949,7 @@ func (s *BeginRwStatement) Execute(session *Session) (*Result, error) {
 		return nil, errors.New("you're in read-only transaction. Please finish the transaction by 'CLOSE;'")
 	}
 
-	if err := session.BeginReadWriteTransaction(s.Priority, s.TransactionTag); err != nil {
+	if err := session.BeginReadWriteTransaction(s.Priority, s.Tag); err != nil {
 		return nil, err
 	}
 
@@ -1008,7 +1008,7 @@ type BeginRoStatement struct {
 	Staleness          time.Duration
 	Timestamp          time.Time
 	Priority           pb.RequestOptions_Priority
-	RequestTag         string
+	Tag                string
 }
 
 func newBeginRoStatement(input string) (*BeginRoStatement, error) {
@@ -1041,7 +1041,7 @@ func newBeginRoStatement(input string) (*BeginRoStatement, error) {
 	}
 
 	if matched[3] != "" {
-		stmt.RequestTag = matched[3]
+		stmt.Tag = matched[3]
 	}
 
 	return stmt, nil
@@ -1057,7 +1057,7 @@ func (s *BeginRoStatement) Execute(session *Session) (*Result, error) {
 		close.Execute(session)
 	}
 
-	ts, err := session.BeginReadOnlyTransaction(s.TimestampBoundType, s.Staleness, s.Timestamp, s.Priority, s.RequestTag)
+	ts, err := session.BeginReadOnlyTransaction(s.TimestampBoundType, s.Staleness, s.Timestamp, s.Priority, s.Tag)
 	if err != nil {
 		return nil, err
 	}

--- a/statement_test.go
+++ b/statement_test.go
@@ -211,6 +211,57 @@ func TestBuildStatement(t *testing.T) {
 			},
 		},
 		{
+			desc:  "BEGIN statement with TAG",
+			input: "BEGIN TAG app=concert,env=dev",
+			want: &BeginRwStatement{
+				TransactionTag: "app=concert,env=dev",
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with TAG",
+			input: "BEGIN RW TAG app=concert,env=dev",
+			want: &BeginRwStatement{
+				TransactionTag: "app=concert,env=dev",
+			},
+		},
+		{
+			desc:  "BEGIN PRIORITY statement with TAG",
+			input: "BEGIN PRIORITY MEDIUM TAG app=concert,env=dev",
+			want: &BeginRwStatement{
+				Priority:       pb.RequestOptions_PRIORITY_MEDIUM,
+				TransactionTag: "app=concert,env=dev",
+			},
+		},
+		{
+			desc:  "BEGIN statement with TAG whitespace",
+			input: "BEGIN TAG app=concert env=dev",
+			want: &BeginRwStatement{
+				TransactionTag: "app=concert env=dev",
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with TAG whitespace",
+			input: "BEGIN RW TAG app=concert env=dev",
+			want: &BeginRwStatement{
+				TransactionTag: "app=concert env=dev",
+			},
+		},
+		{
+			desc:  "BEGIN PRIORITY statement with TAG whitespace",
+			input: "BEGIN PRIORITY MEDIUM TAG app=concert env=dev",
+			want: &BeginRwStatement{
+				Priority:       pb.RequestOptions_PRIORITY_MEDIUM,
+				TransactionTag: "app=concert env=dev",
+			},
+		},
+		{
+			desc:  "BEGIN statement with TAG quoted",
+			input: "BEGIN TAG app=\"concert\" env='dev'",
+			want: &BeginRwStatement{
+				TransactionTag: "app=\"concert\" env='dev'",
+			},
+		},
+		{
 			desc:  "BEGIN RO statement",
 			input: "BEGIN RO",
 			want:  &BeginRoStatement{TimestampBoundType: strong},

--- a/statement_test.go
+++ b/statement_test.go
@@ -212,53 +212,53 @@ func TestBuildStatement(t *testing.T) {
 		},
 		{
 			desc:  "BEGIN statement with TAG",
-			input: "BEGIN TAG app=concert,env=dev",
+			input: "BEGIN TAG app=spanner-cli,env=test",
 			want: &BeginRwStatement{
-				TransactionTag: "app=concert,env=dev",
+				TransactionTag: "app=spanner-cli,env=test",
 			},
 		},
 		{
 			desc:  "BEGIN RW statement with TAG",
-			input: "BEGIN RW TAG app=concert,env=dev",
+			input: "BEGIN RW TAG app=spanner-cli,env=test",
 			want: &BeginRwStatement{
-				TransactionTag: "app=concert,env=dev",
+				TransactionTag: "app=spanner-cli,env=test",
 			},
 		},
 		{
 			desc:  "BEGIN PRIORITY statement with TAG",
-			input: "BEGIN PRIORITY MEDIUM TAG app=concert,env=dev",
+			input: "BEGIN PRIORITY MEDIUM TAG app=spanner-cli,env=test",
 			want: &BeginRwStatement{
 				Priority:       pb.RequestOptions_PRIORITY_MEDIUM,
-				TransactionTag: "app=concert,env=dev",
+				TransactionTag: "app=spanner-cli,env=test",
 			},
 		},
 		{
 			desc:  "BEGIN statement with TAG whitespace",
-			input: "BEGIN TAG app=concert env=dev",
+			input: "BEGIN TAG app=spanner-cli env=test",
 			want: &BeginRwStatement{
-				TransactionTag: "app=concert env=dev",
+				TransactionTag: "app=spanner-cli env=test",
 			},
 		},
 		{
 			desc:  "BEGIN RW statement with TAG whitespace",
-			input: "BEGIN RW TAG app=concert env=dev",
+			input: "BEGIN RW TAG app=spanner-cli env=test",
 			want: &BeginRwStatement{
-				TransactionTag: "app=concert env=dev",
+				TransactionTag: "app=spanner-cli env=test",
 			},
 		},
 		{
 			desc:  "BEGIN PRIORITY statement with TAG whitespace",
-			input: "BEGIN PRIORITY MEDIUM TAG app=concert env=dev",
+			input: "BEGIN PRIORITY MEDIUM TAG app=spanner-cli env=test",
 			want: &BeginRwStatement{
 				Priority:       pb.RequestOptions_PRIORITY_MEDIUM,
-				TransactionTag: "app=concert env=dev",
+				TransactionTag: "app=spanner-cli env=test",
 			},
 		},
 		{
 			desc:  "BEGIN statement with TAG quoted",
-			input: "BEGIN TAG app=\"concert\" env='dev'",
+			input: "BEGIN TAG app=\"spanner-cli\" env='dev'",
 			want: &BeginRwStatement{
-				TransactionTag: "app=\"concert\" env='dev'",
+				TransactionTag: "app=\"spanner-cli\" env='dev'",
 			},
 		},
 		{
@@ -289,6 +289,52 @@ func TestBuildStatement(t *testing.T) {
 				Staleness:          time.Duration(10 * time.Second),
 				TimestampBoundType: exactStaleness,
 				Priority:           pb.RequestOptions_PRIORITY_HIGH,
+			},
+		},
+		{
+			desc:  "BEGIN RO statement with TAG",
+			input: "BEGIN RO TAG app=spanner-cli,env=test",
+			want: &BeginRoStatement{
+				TimestampBoundType: strong,
+				RequestTag:         "app=spanner-cli,env=test",
+			},
+		},
+		{
+			desc:  "BEGIN RO staleness statement with TAG",
+			input: "BEGIN RO 10 TAG app=spanner-cli,env=test",
+			want: &BeginRoStatement{
+				Staleness:          time.Duration(10 * time.Second),
+				TimestampBoundType: exactStaleness,
+				RequestTag:         "app=spanner-cli,env=test",
+			},
+		},
+		{
+			desc:  "BEGIN RO read timestamp statement with TAG",
+			input: "BEGIN RO 2020-03-30T22:54:44.834017+09:00 TAG app=spanner-cli,env=test",
+			want: &BeginRoStatement{
+				Timestamp:          timestamp,
+				TimestampBoundType: readTimestamp,
+				RequestTag:         "app=spanner-cli,env=test",
+			},
+			skipLowerCase: true,
+		},
+		{
+			desc:  "BEGIN RO PRIORITY statement with TAG",
+			input: "BEGIN RO PRIORITY LOW TAG app=spanner-cli,env=test",
+			want: &BeginRoStatement{
+				TimestampBoundType: strong,
+				Priority:           pb.RequestOptions_PRIORITY_LOW,
+				RequestTag:         "app=spanner-cli,env=test",
+			},
+		},
+		{
+			desc:  "BEGIN RO staleness with PRIORITY statement with TAG",
+			input: "BEGIN RO 10 PRIORITY HIGH TAG app=spanner-cli,env=test",
+			want: &BeginRoStatement{
+				Staleness:          time.Duration(10 * time.Second),
+				TimestampBoundType: exactStaleness,
+				Priority:           pb.RequestOptions_PRIORITY_HIGH,
+				RequestTag:         "app=spanner-cli,env=test",
 			},
 		},
 		{

--- a/statement_test.go
+++ b/statement_test.go
@@ -214,51 +214,51 @@ func TestBuildStatement(t *testing.T) {
 			desc:  "BEGIN statement with TAG",
 			input: "BEGIN TAG app=spanner-cli,env=test",
 			want: &BeginRwStatement{
-				TransactionTag: "app=spanner-cli,env=test",
+				Tag: "app=spanner-cli,env=test",
 			},
 		},
 		{
 			desc:  "BEGIN RW statement with TAG",
 			input: "BEGIN RW TAG app=spanner-cli,env=test",
 			want: &BeginRwStatement{
-				TransactionTag: "app=spanner-cli,env=test",
+				Tag: "app=spanner-cli,env=test",
 			},
 		},
 		{
 			desc:  "BEGIN PRIORITY statement with TAG",
 			input: "BEGIN PRIORITY MEDIUM TAG app=spanner-cli,env=test",
 			want: &BeginRwStatement{
-				Priority:       pb.RequestOptions_PRIORITY_MEDIUM,
-				TransactionTag: "app=spanner-cli,env=test",
+				Priority: pb.RequestOptions_PRIORITY_MEDIUM,
+				Tag:      "app=spanner-cli,env=test",
 			},
 		},
 		{
 			desc:  "BEGIN statement with TAG whitespace",
 			input: "BEGIN TAG app=spanner-cli env=test",
 			want: &BeginRwStatement{
-				TransactionTag: "app=spanner-cli env=test",
+				Tag: "app=spanner-cli env=test",
 			},
 		},
 		{
 			desc:  "BEGIN RW statement with TAG whitespace",
 			input: "BEGIN RW TAG app=spanner-cli env=test",
 			want: &BeginRwStatement{
-				TransactionTag: "app=spanner-cli env=test",
+				Tag: "app=spanner-cli env=test",
 			},
 		},
 		{
 			desc:  "BEGIN PRIORITY statement with TAG whitespace",
 			input: "BEGIN PRIORITY MEDIUM TAG app=spanner-cli env=test",
 			want: &BeginRwStatement{
-				Priority:       pb.RequestOptions_PRIORITY_MEDIUM,
-				TransactionTag: "app=spanner-cli env=test",
+				Priority: pb.RequestOptions_PRIORITY_MEDIUM,
+				Tag:      "app=spanner-cli env=test",
 			},
 		},
 		{
 			desc:  "BEGIN statement with TAG quoted",
 			input: "BEGIN TAG app=\"spanner-cli\" env='dev'",
 			want: &BeginRwStatement{
-				TransactionTag: "app=\"spanner-cli\" env='dev'",
+				Tag: "app=\"spanner-cli\" env='dev'",
 			},
 		},
 		{
@@ -296,7 +296,7 @@ func TestBuildStatement(t *testing.T) {
 			input: "BEGIN RO TAG app=spanner-cli,env=test",
 			want: &BeginRoStatement{
 				TimestampBoundType: strong,
-				RequestTag:         "app=spanner-cli,env=test",
+				Tag:                "app=spanner-cli,env=test",
 			},
 		},
 		{
@@ -305,7 +305,7 @@ func TestBuildStatement(t *testing.T) {
 			want: &BeginRoStatement{
 				Staleness:          time.Duration(10 * time.Second),
 				TimestampBoundType: exactStaleness,
-				RequestTag:         "app=spanner-cli,env=test",
+				Tag:                "app=spanner-cli,env=test",
 			},
 		},
 		{
@@ -314,7 +314,7 @@ func TestBuildStatement(t *testing.T) {
 			want: &BeginRoStatement{
 				Timestamp:          timestamp,
 				TimestampBoundType: readTimestamp,
-				RequestTag:         "app=spanner-cli,env=test",
+				Tag:                "app=spanner-cli,env=test",
 			},
 			skipLowerCase: true,
 		},
@@ -324,7 +324,7 @@ func TestBuildStatement(t *testing.T) {
 			want: &BeginRoStatement{
 				TimestampBoundType: strong,
 				Priority:           pb.RequestOptions_PRIORITY_LOW,
-				RequestTag:         "app=spanner-cli,env=test",
+				Tag:                "app=spanner-cli,env=test",
 			},
 		},
 		{
@@ -334,7 +334,7 @@ func TestBuildStatement(t *testing.T) {
 				Staleness:          time.Duration(10 * time.Second),
 				TimestampBoundType: exactStaleness,
 				Priority:           pb.RequestOptions_PRIORITY_HIGH,
-				RequestTag:         "app=spanner-cli,env=test",
+				Tag:                "app=spanner-cli,env=test",
 			},
 		},
 		{


### PR DESCRIPTION
This PR adds Cloud Spanner's [transaction tags and request tags](https://cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags) support to spanner-cli.

Transaction tags are tags set at the beginning of a transaction that makes the transaction identifiable. Request tags can be set for each request and identify individual requests.

According to [this document](https://cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags#mapping_between_api_methods_and_requesttransaction_tag), read-write transaction supports transaction tags and request tags. Read-only transaction only supports request tags.

So, I implemented this feature as follows.

##  Transaction Tags and Request Tags support in spanner-cli

In a read-write transaction, you can add arbitrary tags following `BEGIN RW TAG <tags>`.
spanner-cli adds the tags set in `BEGIN RW TAG` as transaction tags.
This tag will also be used as request tags within the transaction.

```
# Read-write transaction
# transaction_tag = tx1
+--------------------+
| BEGIN RW TAG tx1;  |
|                    |
| SELECT val         |
| FROM tab1      +-----request_tag = tx1
| WHERE id = 1;      |
|                    |
| UPDATE tab1        |
| SET val = 10   +-----request_tag = tx1
| WHERE id = 1;      |
|                    |
| COMMIT;            |
+--------------------+
```

In a read-only transaction, you can add arbitrary tags following `BEGIN RO TAG <tags>`.
Since read-only transaction in Cloud Spanner doesn't support transaction tags, spanner-cli adds the tags set in `BEGIN RO TAG` as request tags.
```
# Read-only transaction
# transaction_tag = N/A
+--------------------+
| BEGIN RO TAG tx2;  |
|                    |
| SELECT SUM(val)    |
| FROM tab1      +-----request_tag = tx2
| WHERE id = 1;      |
|                    |
| CLOSE;             |
+--------------------+
```