### PR TITLE
Remove EXPERIMENTAL flag for query execution plan

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -126,7 +126,7 @@ var (
 )
 
 var (
-	explainColumnNames        = []string{"ID", "Query_Execution_Plan (EXPERIMENTAL)"}
+	explainColumnNames        = []string{"ID", "Query_Execution_Plan"}
 	explainAnalyzeColumnNames = []string{"ID", "Query_Execution_Plan", "Rows_Returned", "Executions", "Total_Latency"}
 )
 


### PR DESCRIPTION
I hope `EXPLAIN SELECT ...` statement has been battle-tested and it's no more in experimental phase. Let's remove it.