### PR TITLE
Handles SIGINT (Ctr-C) and gracefully stops an inflight request.

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -85,7 +85,7 @@ func setup(t *testing.T, ctx context.Context, dmls []string) (*Session, string, 
 	if testCredential != "" {
 		options = append(options, option.WithCredentialsJSON([]byte(testCredential)))
 	}
-	session, err := NewSession(ctx, testProjectId, testInstanceId, testDatabaseId, pb.RequestOptions_PRIORITY_UNSPECIFIED, options...)
+	session, err := NewSession(testProjectId, testInstanceId, testDatabaseId, pb.RequestOptions_PRIORITY_UNSPECIFIED, options...)
 	if err != nil {
 		t.Fatalf("failed to create test session: err=%s", err)
 	}
@@ -114,7 +114,7 @@ func setup(t *testing.T, ctx context.Context, dmls []string) (*Session, string, 
 	for _, dml := range dmls {
 		dml = strings.Replace(dml, "[[TABLE]]", tableId, -1)
 		stmt := spanner.NewStatement(dml)
-		_, err := session.client.ReadWriteTransaction(session.ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		_, err := session.client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 			_, err = txn.Update(ctx, stmt)
 			if err != nil {
 				t.Fatalf("failed to apply DML: dml=%s, err=%s", dml, err)
@@ -171,7 +171,7 @@ func TestSelect(t *testing.T) {
 		t.Fatalf("invalid statement: error=%s", err)
 	}
 
-	result, err := stmt.Execute(session)
+	result, err := stmt.Execute(ctx, session)
 	if err != nil {
 		t.Fatalf("unexpected error happened: %s", err)
 	}
@@ -203,7 +203,7 @@ func TestDml(t *testing.T) {
 		t.Fatalf("invalid statement: error=%s", err)
 	}
 
-	result, err := stmt.Execute(session)
+	result, err := stmt.Execute(ctx, session)
 	if err != nil {
 		t.Fatalf("unexpected error happened: %s", err)
 	}
@@ -259,7 +259,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err := stmt.Execute(session)
+		result, err := stmt.Execute(ctx, session)
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -275,7 +275,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(session)
+		result, err = stmt.Execute(ctx, session)
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -291,7 +291,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(session)
+		result, err = stmt.Execute(ctx, session)
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -342,7 +342,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err := stmt.Execute(session)
+		result, err := stmt.Execute(ctx, session)
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -358,7 +358,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(session)
+		result, err = stmt.Execute(ctx, session)
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -374,7 +374,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(session)
+		result, err = stmt.Execute(ctx, session)
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -409,7 +409,7 @@ func TestReadWriteTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		if _, err := stmt.Execute(session); err != nil {
+		if _, err := stmt.Execute(ctx, session); err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
 
@@ -454,7 +454,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err := stmt.Execute(session)
+		result, err := stmt.Execute(ctx, session)
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -470,7 +470,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(session)
+		result, err = stmt.Execute(ctx, session)
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -491,7 +491,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err = stmt.Execute(session)
+		result, err = stmt.Execute(ctx, session)
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -520,7 +520,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 		if err != nil {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
-		if _, err := stmt.Execute(session); err != nil {
+		if _, err := stmt.Execute(ctx, session); err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
 
@@ -530,7 +530,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		if _, err := stmt.Execute(session); err != nil {
+		if _, err := stmt.Execute(ctx, session); err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
 
@@ -540,7 +540,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		result, err := stmt.Execute(session)
+		result, err := stmt.Execute(ctx, session)
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -562,7 +562,7 @@ func TestReadOnlyTransaction(t *testing.T) {
 			t.Fatalf("invalid statement: error=%s", err)
 		}
 
-		_, err = stmt.Execute(session)
+		_, err = stmt.Execute(ctx, session)
 		if err != nil {
 			t.Fatalf("unexpected error happened: %s", err)
 		}
@@ -585,7 +585,7 @@ func TestShowCreateTable(t *testing.T) {
 		t.Fatalf("invalid statement: error=%s", err)
 	}
 
-	result, err := stmt.Execute(session)
+	result, err := stmt.Execute(ctx, session)
 	if err != nil {
 		t.Fatalf("unexpected error happened: %s", err)
 	}
@@ -616,7 +616,7 @@ func TestShowColumns(t *testing.T) {
 		t.Fatalf("invalid statement: error=%s", err)
 	}
 
-	result, err := stmt.Execute(session)
+	result, err := stmt.Execute(ctx, session)
 	if err != nil {
 		t.Fatalf("unexpected error happened: %s", err)
 	}
@@ -648,7 +648,7 @@ func TestShowIndexes(t *testing.T) {
 		t.Fatalf("invalid statement: error=%s", err)
 	}
 
-	result, err := stmt.Execute(session)
+	result, err := stmt.Execute(ctx, session)
 	if err != nil {
 		t.Fatalf("unexpected error happened: %s", err)
 	}
@@ -681,7 +681,7 @@ func TestTruncateTable(t *testing.T) {
 		t.Fatalf("invalid statement: %v", err)
 	}
 
-	if _, err := stmt.Execute(session); err != nil {
+	if _, err := stmt.Execute(ctx, session); err != nil {
 		t.Fatalf("execution failed: %v", err)
 	}
 
@@ -717,7 +717,7 @@ func TestPartitionedDML(t *testing.T) {
 		t.Fatalf("invalid statement: %v", err)
 	}
 
-	if _, err := stmt.Execute(session); err != nil {
+	if _, err := stmt.Execute(ctx, session); err != nil {
 		t.Fatalf("execution failed: %v", err)
 	}
 

--- a/session_test.go
+++ b/session_test.go
@@ -64,33 +64,33 @@ func TestRequestPriority(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			defer recorder.flush()
 
-			session, err := NewSession(ctx, "project", "instance", "database", test.sessionPriority, option.WithGRPCConn(conn))
+			session, err := NewSession("project", "instance", "database", test.sessionPriority, option.WithGRPCConn(conn))
 			if err != nil {
 				t.Fatalf("failed to create spanner-cli session: %v", err)
 			}
 
 			// Read-Write Transaction.
-			if err := session.BeginReadWriteTransaction(test.transactionPriority, ""); err != nil {
+			if err := session.BeginReadWriteTransaction(ctx, test.transactionPriority, ""); err != nil {
 				t.Fatalf("failed to begin read write transaction: %v", err)
 			}
-			iter, _ := session.RunQuery(spanner.NewStatement("SELECT * FROM t1"))
+			iter, _ := session.RunQuery(ctx, spanner.NewStatement("SELECT * FROM t1"))
 			if err := iter.Do(func(r *spanner.Row) error {
 				return nil
 			}); err != nil {
 				t.Fatalf("failed to run query: %v", err)
 			}
-			if _, err := session.RunUpdate(spanner.NewStatement("DELETE FROM t1 WHERE Id = 1")); err != nil {
+			if _, err := session.RunUpdate(ctx, spanner.NewStatement("DELETE FROM t1 WHERE Id = 1")); err != nil {
 				t.Fatalf("failed to run update: %v", err)
 			}
-			if _, err := session.CommitReadWriteTransaction(); err != nil {
+			if _, err := session.CommitReadWriteTransaction(ctx); err != nil {
 				t.Fatalf("failed to commit: %v", err)
 			}
 
 			// Read-Only Transaction.
-			if _, err := session.BeginReadOnlyTransaction(strong, 0, time.Now(), test.transactionPriority, ""); err != nil {
+			if _, err := session.BeginReadOnlyTransaction(ctx, strong, 0, time.Now(), test.transactionPriority, ""); err != nil {
 				t.Fatalf("failed to begin read only transaction: %v", err)
 			}
-			iter, _ = session.RunQueryWithStats(spanner.NewStatement("SELECT * FROM t1"))
+			iter, _ = session.RunQueryWithStats(ctx, spanner.NewStatement("SELECT * FROM t1"))
 			if err := iter.Do(func(r *spanner.Row) error {
 				return nil
 			}); err != nil {


### PR DESCRIPTION
Currently spanner-cli doesn't handle `SIGINT`, so if it receives `SIGINT` in response to the `Ctrl-C`, the CLI is killed suddenly and inflight request is not canceled properly.

This PR handles the `SIGINT` properly for both interactive mode and batch mode. This PR also removes the `Session.ctx` field, which was not used effectively at this moment.

More background: #133

## Example

### Interactive mode
```
spanner> SELECT COUNT(*) FROM t1;
^CERROR: spanner: code = "Canceled", desc = "context canceled"
```

### Batch mode
```
spanner-cli -p <PROJECT> -i <INSTANCE> -d <DATABASE> -e 'SELECT COUNT(*) FROM t1;'
^CERROR: spanner: code = "Canceled", desc = "context canceled
```