### PR TITLE
Support generic DDLs

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -85,15 +85,12 @@ var (
 	selectRe = regexp.MustCompile(`(?is)^(?:WITH|@{.+|SELECT)\s.+$`)
 
 	// DDL
-	createDatabaseRe  = regexp.MustCompile(`(?is)^CREATE\s+DATABASE\s.+$`)
-	dropDatabaseRe    = regexp.MustCompile(`(?is)^DROP\s+DATABASE\s+(.+)$`)
-	alterDatabaseRe   = regexp.MustCompile(`(?is)^ALTER\s+DATABASE\s.+$`)
-	createRe          = regexp.MustCompile(`(?is)^CREATE\s.+$`)
-	dropRe            = regexp.MustCompile(`(?is)^DROP\s.+$`)
-	alterRe           = regexp.MustCompile(`(?is)^ALTER\s.+$`)
-	alterTableRe      = regexp.MustCompile(`(?is)^ALTER\s+TABLE\s.+$`)
-	truncateTableRe   = regexp.MustCompile(`(?is)^TRUNCATE\s+TABLE\s+(.+)$`)
-	alterStatisticsRe = regexp.MustCompile(`(?is)^ALTER\s+STATISTICS\s.+$`)
+	createDatabaseRe = regexp.MustCompile(`(?is)^CREATE\s+DATABASE\s.+$`)
+	dropDatabaseRe   = regexp.MustCompile(`(?is)^DROP\s+DATABASE\s+(.+)$`)
+	createRe         = regexp.MustCompile(`(?is)^CREATE\s.+$`)
+	dropRe           = regexp.MustCompile(`(?is)^DROP\s.+$`)
+	alterRe          = regexp.MustCompile(`(?is)^ALTER\s.+$`)
+	truncateTableRe  = regexp.MustCompile(`(?is)^TRUNCATE\s+TABLE\s+(.+)$`)
 
 	// DML
 	dmlRe = regexp.MustCompile(`(?is)^(INSERT|UPDATE|DELETE)\s+.+$`)

--- a/statement.go
+++ b/statement.go
@@ -132,21 +132,15 @@ func BuildStatement(input string) (Statement, error) {
 		return &UseStatement{Database: unquoteIdentifier(matched[1])}, nil
 	case selectRe.MatchString(input):
 		return &SelectStatement{Query: input}, nil
+	case createDatabaseRe.MatchString(input):
+		return &CreateDatabaseStatement{CreateStatement: input}, nil
 	case createRe.MatchString(input):
-		switch {
-		case createDatabaseRe.MatchString(input):
-			return &CreateDatabaseStatement{CreateStatement: input}, nil
-		default:
-			return &DdlStatement{Ddl: input}, nil
-		}
+		return &DdlStatement{Ddl: input}, nil
+	case dropDatabaseRe.MatchString(input):
+		matched := dropDatabaseRe.FindStringSubmatch(input)
+		return &DropDatabaseStatement{DatabaseId: unquoteIdentifier(matched[1])}, nil
 	case dropRe.MatchString(input):
-		switch {
-		case dropDatabaseRe.MatchString(input):
-			matched := dropDatabaseRe.FindStringSubmatch(input)
-			return &DropDatabaseStatement{DatabaseId: unquoteIdentifier(matched[1])}, nil
-		default:
-			return &DdlStatement{Ddl: input}, nil
-		}
+		return &DdlStatement{Ddl: input}, nil
 	case alterRe.MatchString(input):
 		return &DdlStatement{Ddl: input}, nil
 	case truncateTableRe.MatchString(input):

--- a/statement_test.go
+++ b/statement_test.go
@@ -472,11 +472,6 @@ func TestBuildStatement(t *testing.T) {
 			input: "DESC SELECT * FROM t1",
 			want:  &ExplainStatement{Explain: "SELECT * FROM t1"},
 		},
-		{
-			desc:  "DESC SELECT statement",
-			input: "DESC SELECT * FROM t1",
-			want:  &ExplainStatement{Explain: "SELECT * FROM t1"},
-		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			got, err := BuildStatement(test.input)

--- a/statement_test.go
+++ b/statement_test.go
@@ -127,6 +127,36 @@ func TestBuildStatement(t *testing.T) {
 			want:  &DdlStatement{Ddl: "DROP VIEW t1view"},
 		},
 		{
+			desc:  "CREATE CHANGE STREAM FOR ALL statement",
+			input: "CREATE CHANGE STREAM EverythingStream FOR ALL",
+			want:  &DdlStatement{Ddl: "CREATE CHANGE STREAM EverythingStream FOR ALL"},
+		},
+		{
+			desc:  "CREATE CHANGE STREAM FOR specific columns statement",
+			input: "CREATE CHANGE STREAM NamesAndTitles FOR Singers(FirstName, LastName), Albums(Title)",
+			want:  &DdlStatement{Ddl: "CREATE CHANGE STREAM NamesAndTitles FOR Singers(FirstName, LastName), Albums(Title)"},
+		},
+		{
+			desc:  "ALTER CHANGE STREAM SET FOR statement",
+			input: "ALTER CHANGE STREAM NamesAndAlbums SET FOR Singers(FirstName, LastName), Albums, Songs",
+			want:  &DdlStatement{Ddl: "ALTER CHANGE STREAM NamesAndAlbums SET FOR Singers(FirstName, LastName), Albums, Songs"},
+		},
+		{
+			desc:  "ALTER CHANGE STREAM SET OPTIONS statement",
+			input: "ALTER CHANGE STREAM NamesAndAlbums SET OPTIONS( retention_period = '36h' )",
+			want:  &DdlStatement{Ddl: "ALTER CHANGE STREAM NamesAndAlbums SET OPTIONS( retention_period = '36h' )"},
+		},
+		{
+			desc:  "ALTER CHANGE STREAM DROP FOR ALL statement",
+			input: "ALTER CHANGE STREAM MyStream DROP FOR ALL",
+			want:  &DdlStatement{Ddl: "ALTER CHANGE STREAM MyStream DROP FOR ALL"},
+		},
+		{
+			desc:  "DROP CHANGE STREAM statement",
+			input: "DROP CHANGE STREAM NamesAndAlbums",
+			want:  &DdlStatement{Ddl: "DROP CHANGE STREAM NamesAndAlbums"},
+		},
+		{
 			desc:  "ALTER STATISTICS statement",
 			input: "ALTER STATISTICS package SET OPTIONS (allow_gc = false)",
 			want:  &DdlStatement{Ddl: "ALTER STATISTICS package SET OPTIONS (allow_gc = false)"},
@@ -435,6 +465,11 @@ func TestBuildStatement(t *testing.T) {
 		{
 			desc:  "DESCRIBE SELECT statement",
 			input: "DESCRIBE SELECT * FROM t1",
+			want:  &ExplainStatement{Explain: "SELECT * FROM t1"},
+		},
+		{
+			desc:  "DESC SELECT statement",
+			input: "DESC SELECT * FROM t1",
 			want:  &ExplainStatement{Explain: "SELECT * FROM t1"},
 		},
 		{


### PR DESCRIPTION
This PR adds the generic DDLs(`CREATE / ALTER / DROP`) support.

```
spanner> CREATE CHANGE STREAM EverythingStream FOR ALL;
Query OK, 0 rows affected (24.15 sec)

spanner> ALTER CHANGE STREAM EverythingStream DROP FOR ALL;
Query OK, 0 rows affected (7.07 sec)

spanner> DROP CHANGE STREAM EverythingStream;
Query OK, 0 rows affected (17.15 sec)
```

We can specialize the regex pattern and the statement like `CREATE DATABASE` and `DROP DATABASE` statements if needed.

fixes #135 