### PR TITLE
Make the history file path to be configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,16 +33,17 @@ type globalOptions struct {
 }
 
 type spannerOptions struct {
-	ProjectId  string `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
-	InstanceId string `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID"`
-	DatabaseId string `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
-	Execute    string `short:"e" long:"execute" description:"Execute SQL statement and quit."`
-	File       string `short:"f" long:"file" description:"Execute SQL statement from file and quit."`
-	Table      bool   `short:"t" long:"table" description:"Display output in table format for batch mode."`
-	Verbose    bool   `short:"v" long:"verbose" description:"Display verbose output."`
-	Credential string `long:"credential" description:"Use the specific credential file"`
-	Prompt     string `long:"prompt" description:"Set the prompt to the specified format"`
-	Priority   string `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
+	ProjectId   string `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
+	InstanceId  string `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID"`
+	DatabaseId  string `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
+	Execute     string `short:"e" long:"execute" description:"Execute SQL statement and quit."`
+	File        string `short:"f" long:"file" description:"Execute SQL statement from file and quit."`
+	Table       bool   `short:"t" long:"table" description:"Display output in table format for batch mode."`
+	Verbose     bool   `short:"v" long:"verbose" description:"Display verbose output."`
+	Credential  string `long:"credential" description:"Use the specific credential file"`
+	Prompt      string `long:"prompt" description:"Set the prompt to the specified format"`
+	HistoryFile string `long:"history" description:"Set the history file to the specified path"`
+	Priority    string `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
 }
 
 func main() {
@@ -83,7 +84,7 @@ func main() {
 		}
 	}
 
-	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority)
+	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority)
 	if err != nil {
 		exitf("Failed to connect to Spanner: %v", err)
 	}


### PR DESCRIPTION
Add `--history` option in order to make the history file path to be configurable.

- Currently, the history file path is fixed as `/tmp/spanner_cli_readline.tmp`. But, I'd like to make the file path to be configurable. 
    - In my case, I'm using `docker compose` to run `spanner-cli` and would like to preserve the history file across the `docker compose run`. Thought I can mount the current `/tmp/spanner_cli_readline.tmp` into the container, I think making the history file path to be configurable is a more explicit and easy way to preserve the histories. (Other database client like `mysql` or `psql` also provide the way to change the history file path).