### PR TITLE
Add fine-grained ACL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ and `{}` for a mutually exclusive keyword.
 | Truncate table | `TRUNCATE TABLE <table>;` | Only rows are deleted. Note: Non-atomically because executed as a [partitioned DML statement](https://cloud.google.com/spanner/docs/dml-partitioned?hl=en). |
 | Create index | `CREATE INDEX ...;` | |
 | Delete index | `DROP INDEX ...;` | |
+| Create role | `CREATE ROLE ...;` | |
+| Drop role | `DROP ROLE ...;` | |
+| Grant | `GRANT ...;` | |
+| Revoke | `REVOKE ...;` | |
 | Query | `SELECT ...;` | |
 | DML | `{INSERT\|UPDATE\|DELETE} ...;` | |
 | Partitioned DML | `PARTITIONED {UPDATE\|DELETE} ...;` | |

--- a/statement.go
+++ b/statement.go
@@ -89,6 +89,8 @@ var (
 	dropDatabaseRe   = regexp.MustCompile(`(?is)^DROP\s+DATABASE\s+(.+)$`)
 	createRe         = regexp.MustCompile(`(?is)^CREATE\s.+$`)
 	dropRe           = regexp.MustCompile(`(?is)^DROP\s.+$`)
+	grantRe          = regexp.MustCompile(`(?is)^GRANT\s.+$`)
+	revokeRe         = regexp.MustCompile(`(?is)^REVOKE\s.+$`)
 	alterRe          = regexp.MustCompile(`(?is)^ALTER\s.+$`)
 	truncateTableRe  = regexp.MustCompile(`(?is)^TRUNCATE\s+TABLE\s+(.+)$`)
 
@@ -142,6 +144,10 @@ func BuildStatement(input string) (Statement, error) {
 	case dropRe.MatchString(input):
 		return &DdlStatement{Ddl: input}, nil
 	case alterRe.MatchString(input):
+		return &DdlStatement{Ddl: input}, nil
+	case grantRe.MatchString(input):
+		return &DdlStatement{Ddl: input}, nil
+	case revokeRe.MatchString(input):
 		return &DdlStatement{Ddl: input}, nil
 	case truncateTableRe.MatchString(input):
 		matched := truncateTableRe.FindStringSubmatch(input)

--- a/statement_test.go
+++ b/statement_test.go
@@ -157,6 +157,16 @@ func TestBuildStatement(t *testing.T) {
 			want:  &DdlStatement{Ddl: "DROP CHANGE STREAM NamesAndAlbums"},
 		},
 		{
+			desc:  "GRANT statement",
+			input: "GRANT SELECT ON TABLE employees TO ROLE hr_rep",
+			want:  &DdlStatement{Ddl: "GRANT SELECT ON TABLE employees TO ROLE hr_rep"},
+		},
+		{
+			desc:  "REVOKE statement",
+			input: "REVOKE SELECT ON TABLE employees FROM ROLE hr_rep",
+			want:  &DdlStatement{Ddl: "REVOKE SELECT ON TABLE employees FROM ROLE hr_rep"},
+		},
+		{
 			desc:  "ALTER STATISTICS statement",
 			input: "ALTER STATISTICS package SET OPTIONS (allow_gc = false)",
 			want:  &DdlStatement{Ddl: "ALTER STATISTICS package SET OPTIONS (allow_gc = false)"},


### PR DESCRIPTION
This PR adds fine-grained ACL related DDLs support(`GRANT`, `REVOKE`).

```
spanner> CREATE ROLE singers_reader;
Query OK, 0 rows affected (6.89 sec)

spanner> GRANT SELECT ON TABLE Singers TO ROLE singers_reader;
Query OK, 0 rows affected (6.49 sec)

spanner> REVOKE SELECT ON TABLE Singers FROM ROLE singers_reader;
Query OK, 0 rows affected (7.47 sec)

spanner> DROP ROLE singers_reader;
Query OK, 0 rows affected (6.52 sec)

```

close #139 