### PR TITLE
support THEN RETURN in DmlStatement

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -79,7 +79,7 @@ func TestRequestPriority(t *testing.T) {
 			}); err != nil {
 				t.Fatalf("failed to run query: %v", err)
 			}
-			if _, err := session.RunUpdate(ctx, spanner.NewStatement("DELETE FROM t1 WHERE Id = 1")); err != nil {
+			if _, _, _, err := session.RunUpdate(ctx, spanner.NewStatement("DELETE FROM t1 WHERE Id = 1"), true); err != nil {
 				t.Fatalf("failed to run update: %v", err)
 			}
 			if _, err := session.CommitReadWriteTransaction(ctx); err != nil {

--- a/statement.go
+++ b/statement.go
@@ -744,7 +744,7 @@ func (s *DmlStatement) Execute(ctx context.Context, session *Session) (*Result, 
 	var numRows int64
 	var err error
 	if session.InReadWriteTransaction() {
-		rows, columnNames, numRows, err = session.RunUpdate(ctx, stmt)
+		rows, columnNames, numRows, err = session.RunUpdate(ctx, stmt, false)
 		if err != nil {
 			// Need to call rollback to free the acquired session in underlying google-cloud-go/spanner.
 			rollback := &RollbackStatement{}
@@ -758,7 +758,7 @@ func (s *DmlStatement) Execute(ctx context.Context, session *Session) (*Result, 
 			return nil, err
 		}
 
-		rows, columnNames, numRows, err = session.RunUpdate(ctx, stmt)
+		rows, columnNames, numRows, err = session.RunUpdate(ctx, stmt, false)
 		if err != nil {
 			// once error has happened, escape from implicit transaction
 			rollback := &RollbackStatement{}


### PR DESCRIPTION
Support to show result sets of `DmlStatement`.

DMLs with `THEN RETURN`
```
spanner> INSERT t1(pk) VALUES(1),(2) THEN RETURN *;
+----+------+
| pk | col  |
+----+------+
| 1  | NULL |
| 2  | NULL |
+----+------+
Query OK, 2 rows affected (0.03 sec)
timestamp:      2023-03-24T16:31:01.252904+09:00
mutation_count: 2

spanner> UPDATE t1 SET col = pk WHERE TRUE THEN RETURN *;
+----+-----+
| pk | col |
+----+-----+
| 1  | 1   |
| 2  | 2   |
+----+-----+
Query OK, 2 rows affected (0.03 sec)
timestamp:      2023-03-24T16:31:07.653541+09:00
mutation_count: 4

spanner> DELETE t1 WHERE TRUE THEN RETURN *;
+----+-----+
| pk | col |
+----+-----+
| 1  | 1   |
| 2  | 2   |
+----+-----+
Query OK, 2 rows affected (0.04 sec)
timestamp:      2023-03-24T16:31:16.285057+09:00
mutation_count: 2
```

normal DMLs

```
spanner> INSERT t1(pk) VALUES(1),(2);
Query OK, 2 rows affected (0.03 sec)
timestamp:      2023-03-24T16:30:38.977739+09:00
mutation_count: 2

spanner> UPDATE t1 SET col = pk WHERE TRUE;
Query OK, 2 rows affected (0.03 sec)
timestamp:      2023-03-24T16:30:45.756416+09:00
mutation_count: 4

spanner> DELETE t1 WHERE TRUE;
Query OK, 2 rows affected (0.04 sec)
timestamp:      2023-03-24T16:30:51.337661+09:00
mutation_count: 2
```


fixes #151 