### PR TITLE
Permit a comment after the last semicolon

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -467,6 +467,11 @@ func buildCommands(input string) ([]*command, error) {
 	var cmds []*command
 	var pendingDdls []string
 	for _, separated := range separateInput(input) {
+		// Ignore the last empty statement
+		if separated.delim == delimiterUndefined && separated.statementWithoutComments == "" {
+			continue
+		}
+
 		stmt, err := BuildStatementWithComments(separated.statementWithoutComments, separated.statement)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR fixes a bug introduced by #150.

## Intended behavior

Valid because of a comment after the last semicolon.
```
SELECT 1; /* comment */
```
Invalid because empty statements terminated by semicolons are not permitted.
```
SELECT 1; /* comment */; SELECT 2
```

fixes #153