### PR TITLE
support stored system procedures

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -82,7 +82,7 @@ type QueryStats struct {
 
 var (
 	// SQL
-	selectRe = regexp.MustCompile(`(?is)^(?:WITH|@{.+|SELECT)\s.+$`)
+	selectRe = regexp.MustCompile(`(?is)^(?:WITH|CALL|@{.+|SELECT)\s.+$`)
 
 	// DDL
 	createDatabaseRe = regexp.MustCompile(`(?is)^CREATE\s+DATABASE\s.+$`)

--- a/statement_test.go
+++ b/statement_test.go
@@ -507,6 +507,21 @@ func TestBuildStatement(t *testing.T) {
 			input: "DESC SELECT * FROM t1",
 			want:  &ExplainStatement{Explain: "SELECT * FROM t1"},
 		},
+		{
+			desc:  "Stored system procedures",
+			input: `CALL cancel_query("1234567890123456789")`,
+			want:  &SelectStatement{Query: `CALL cancel_query("1234567890123456789")`},
+		},
+		{
+			desc:  "EXPLAIN Stored system procedures",
+			input: `EXPLAIN CALL cancel_query("1234567890123456789")`,
+			want:  &ExplainStatement{Explain: `CALL cancel_query("1234567890123456789")`},
+		},
+		{
+			desc:  "EXPLAIN ANALYZE Stored system procedures",
+			input: `EXPLAIN ANALYZE CALL cancel_query("1234567890123456789")`,
+			want:  &ExplainAnalyzeStatement{Query: `CALL cancel_query("1234567890123456789")`},
+		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			got, err := BuildStatement(test.input)


### PR DESCRIPTION
From this release [^1], [Stored system procedures](https://cloud.google.com/spanner/docs/reference/standard-sql/stored-procedures) is supported.

As I tested at cloud console [^2], it runs as query.
So I changed statement.go to parse `CALL` to `SelectStatement` and it works.
Let me know if we need to parse `CALL` statement to another struct. 

<details><summary>Test Result (Click me)</summary>

- run heavy query
```
spanner> SELECT * FROM Users AS a CROSS JOIN Users AS b;
```
- select query_id and run stored system procedures
```
spanner> SELECT * FROM spanner_sys.oldest_active_queries;
+-----------------------------+----------------------+-------------------------------------------------+----------------+----------------------------------------------------------------+---------------------+
| START_TIME                  | TEXT_FINGERPRINT     | TEXT                                            | TEXT_TRUNCATED | SESSION_ID                                                     | QUERY_ID            |
+-----------------------------+----------------------+-------------------------------------------------+----------------+----------------------------------------------------------------+---------------------+
| 2024-07-04T02:56:49.130403Z | -2292417946475336118 | SELECT * FROM Users AS a CROSS JOIN Users AS b  | false          | AJ4XPT3hwhcYscZWWnmr-bL5ZhBHztPGqTytWk7dXF29MfFcCTHdk7c5G6LAfQ | 3962375048429130423 |
| 2024-07-04T02:56:49.803515Z | 2871458697993773986  | SELECT * FROM spanner_sys.oldest_active_queries | false          | AJ4XPT2FaN-3h6jc8Xo4knSl4ak8PRrVcbK3SUe5mf_M3kRM--w_PjKh4BLiAg | 951441015441622781  |
+-----------------------------+----------------------+-------------------------------------------------+----------------+----------------------------------------------------------------+---------------------+
2 rows in set (11.44 msecs)
timestamp:            2024-07-04T11:56:49.803681+09:00
cpu time:             0.61 msecs
rows scanned:         0 rows
deleted rows scanned: 0 rows
optimizer version:    6
optimizer statistics: auto_20240703_12_32_08UTC

spanner> CALL cancel_query("3962375048429130423");
Empty set (19.1 msecs)
timestamp:            2024-07-04T11:56:56.343631+09:00
cpu time:             1.81 msecs
rows scanned:         0 rows
deleted rows scanned: 0 rows
optimizer version:    6
optimizer statistics: auto_20240703_12_32_08UTC

spanner>
```
- query is canceled
```
spanner> SELECT * FROM Users AS a CROSS JOIN Users AS b;
ERROR: spanner: code = "Canceled", desc = "The operation was cancelled."
spanner>
```
- explain
```
spanner> EXPLAIN CALL cancel_query("3962375048429130423");
+----+----------------------+
| ID | Query_Execution_Plan |
+----+----------------------+
|  0 | Serialize Result     |
|  1 | +- TVF               |
|  2 |    +- Unit Relation  |
+----+----------------------+
1 rows in set (0.10 sec)

spanner> EXPLAIN ANALYZE CALL cancel_query("3962375048429130423");
+----+----------------------+---------------+------------+---------------+
| ID | Query_Execution_Plan | Rows_Returned | Executions | Total_Latency |
+----+----------------------+---------------+------------+---------------+
|  0 | Serialize Result     | 0             | 1          | 1.01 secs     |
|  1 | +- TVF               | 0             | 1          | 1.01 secs     |
|  2 |    +- Unit Relation  |               |            |               |
+----+----------------------+---------------+------------+---------------+
Empty set (1.01 secs)
timestamp:            2024-07-04T11:58:09.291468+09:00
cpu time:             1.28 msecs
rows scanned:         0 rows
deleted rows scanned: 0 rows
optimizer version:    6
optimizer statistics: auto_20240703_12_32_08UTC

spanner>
```

</details>


[^1]: https://cloud.google.com/spanner/docs/release-notes#July_03_2024
[^2]: 
<img width="1117" alt="image" src="https://github.com/cloudspannerecosystem/spanner-cli/assets/7553415/e889fb2f-b51e-4989-9a66-76e5e7df2b68">
<img width="1099" alt="image" src="https://github.com/cloudspannerecosystem/spanner-cli/assets/7553415/92cedb9a-5dd3-43bd-90cc-93efbdfdde56">

