### PR TITLE
Support FQN in statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ and `{}` for a mutually exclusive keyword.
 | Create database | `CREATE DATABSE <database>;` | |
 | Drop database | `DROP DATABASE <database>;` | |
 | List tables | `SHOW TABLES [<schema>];` | If schema is not provided, default schema is used |
-| Show table schema | `SHOW CREATE TABLE <table>;` | |
-| Show columns | `SHOW COLUMNS FROM <table>;` | |
-| Show indexes | `SHOW INDEX FROM <table>;` | |
+| Show table schema | `SHOW CREATE TABLE <table>;` | The table can be a FQN.|
+| Show columns | `SHOW COLUMNS FROM <table>;` | The table can be a FQN.|
+| Show indexes | `SHOW INDEX FROM <table>;` | The table can be a FQN.|
 | Create table | `CREATE TABLE ...;` | |
 | Change table schema | `ALTER TABLE ...;` | |
 | Delete table | `DROP TABLE ...;` | |

--- a/statement_test.go
+++ b/statement_test.go
@@ -659,7 +659,7 @@ func TestIsCreateTableDDL(t *testing.T) {
 	}
 }
 
-func TestSplitQualifiedName(t *testing.T) {
+func TestExtractSchemaAndTable(t *testing.T) {
 	for _, tt := range []struct {
 		desc   string
 		input  string
@@ -685,8 +685,20 @@ func TestSplitQualifiedName(t *testing.T) {
 			table:  "table",
 		},
 		{
+			desc:   "FQN with spaces",
+			input:  "schema . table",
+			schema: "schema",
+			table:  "table",
+		},
+		{
 			desc:   "FQN, both schema and table are quoted",
 			input:  "`schema`.`table`",
+			schema: "schema",
+			table:  "table",
+		},
+		{
+			desc:   "FQN with spaces, both schema and table are quoted",
+			input:  "`schema` . `table`",
 			schema: "schema",
 			table:  "table",
 		},
@@ -697,8 +709,20 @@ func TestSplitQualifiedName(t *testing.T) {
 			table:  "table",
 		},
 		{
+			desc:   "FQN with spaces, only schema is quoted",
+			input:  "`schema` . table",
+			schema: "schema",
+			table:  "table",
+		},
+		{
 			desc:   "FQN, only table is quoted",
 			input:  "schema.`table`",
+			schema: "schema",
+			table:  "table",
+		},
+		{
+			desc:   "FQN with spaces, only table is quoted",
+			input:  "schema . `table`",
 			schema: "schema",
 			table:  "table",
 		},
@@ -710,7 +734,7 @@ func TestSplitQualifiedName(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			if schema, table := extractQualifiedName(tt.input); schema != tt.schema || table != tt.table {
+			if schema, table := extractSchemaAndTable(tt.input); schema != tt.schema || table != tt.table {
 				t.Errorf("isCreateTableDDL(%q) = (%v, %v), but want (%v, %v)", tt.input, schema, table, tt.schema, tt.table)
 			}
 		})

--- a/statement_test.go
+++ b/statement_test.go
@@ -443,6 +443,11 @@ func TestBuildStatement(t *testing.T) {
 			want:  &ShowCreateTableStatement{Table: "t1"},
 		},
 		{
+			desc:  "SHOW CREATE TABLE statement with a named schema",
+			input: "SHOW CREATE TABLE sch1.t1",
+			want:  &ShowCreateTableStatement{Schema: "sch1", Table: "t1"},
+		},
+		{
 			desc:  "SHOW CREATE TABLE statement with quoted identifier",
 			input: "SHOW CREATE TABLE `TABLE`",
 			want:  &ShowCreateTableStatement{Table: "TABLE"},
@@ -468,6 +473,11 @@ func TestBuildStatement(t *testing.T) {
 			want:  &ShowIndexStatement{Table: "t1"},
 		},
 		{
+			desc:  "SHOW INDEX statement with a named schema",
+			input: "SHOW INDEX FROM sch1.t1",
+			want:  &ShowIndexStatement{Schema: "sch1", Table: "t1"},
+		},
+		{
 			desc:  "SHOW INDEXES statement",
 			input: "SHOW INDEXES FROM t1",
 			want:  &ShowIndexStatement{Table: "t1"},
@@ -486,6 +496,11 @@ func TestBuildStatement(t *testing.T) {
 			desc:  "SHOW COLUMNS statement",
 			input: "SHOW COLUMNS FROM t1",
 			want:  &ShowColumnsStatement{Table: "t1"},
+		},
+		{
+			desc:  "SHOW COLUMNS statement with a named schema",
+			input: "SHOW COLUMNS FROM sch1.t1",
+			want:  &ShowColumnsStatement{Schema: "sch1", Table: "t1"},
 		},
 		{
 			desc:  "SHOW COLUMNS statement with quoted identifier",

--- a/statement_test.go
+++ b/statement_test.go
@@ -735,7 +735,7 @@ func TestExtractSchemaAndTable(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			if schema, table := extractSchemaAndTable(tt.input); schema != tt.schema || table != tt.table {
-				t.Errorf("isCreateTableDDL(%q) = (%v, %v), but want (%v, %v)", tt.input, schema, table, tt.schema, tt.table)
+				t.Errorf("extractSchemaAndTable(%q) = (%v, %v), but want (%v, %v)", tt.input, schema, table, tt.schema, tt.table)
 			}
 		})
 	}


### PR DESCRIPTION
related #172

This PR adds support of FQN in the below statements.
## `SHOW CREATE TABLE <table>`

```
spanner> SHOW CREATE TABLE Singers;
+---------+----------------------------+
| Table   | Create Table               |
+---------+----------------------------+
| Singers | CREATE TABLE Singers (     |
|         |   SingerId INT64 NOT NULL, |
|         |   FirstName STRING(1024),  |
|         |   LastName STRING(1024),   |
|         |   SingerInfo BYTES(MAX),   |
|         |   BirthDate DATE,          |
|         | ) PRIMARY KEY(SingerId)    |
+---------+----------------------------+
1 rows in set (2.26 sec)

spanner> SHOW CREATE TABLE sch1.Singers;
+--------------+-----------------------------+
| Table        | Create Table                |
+--------------+-----------------------------+
| sch1.Singers | CREATE TABLE sch1.Singers ( |
|              |   SingerId INT64 NOT NULL,  |
|              |   FirstName STRING(1024),   |
|              |   LastName STRING(1024),    |
|              |   SingerInfo BYTES(MAX),    |
|              | ) PRIMARY KEY(SingerId)     |
+--------------+-----------------------------+
1 rows in set (1.68 sec)
```

### `SHOW COLUMNS FROM <table>`

```
spanner> SHOW COLUMNS FROM Singers;
+------------+--------------+------+-------------+-----------+---------+
| Field      | Type         | NULL | Key         | Key_Order | Options |
+------------+--------------+------+-------------+-----------+---------+
| SingerId   | INT64        | NO   | PRIMARY_KEY | ASC       | NULL    |
| FirstName  | STRING(1024) | YES  | INDEX       | ASC       | NULL    |
| LastName   | STRING(1024) | YES  | INDEX       | ASC       | NULL    |
| SingerInfo | BYTES(MAX)   | YES  | NULL        | NULL      | NULL    |
| BirthDate  | DATE         | YES  | NULL        | NULL      | NULL    |
+------------+--------------+------+-------------+-----------+---------+
5 rows in set (0.21 sec)

spanner> SHOW COLUMNS FROM sch1.Singers;
+------------+--------------+------+-------------+-----------+---------+
| Field      | Type         | NULL | Key         | Key_Order | Options |
+------------+--------------+------+-------------+-----------+---------+
| SingerId   | INT64        | NO   | PRIMARY_KEY | ASC       | NULL    |
| FirstName  | STRING(1024) | YES  | INDEX       | ASC       | NULL    |
| LastName   | STRING(1024) | YES  | NULL        | NULL      | NULL    |
| SingerInfo | BYTES(MAX)   | YES  | NULL        | NULL      | NULL    |
+------------+--------------+------+-------------+-----------+---------+
4 rows in set (0.31 sec)
```

### `SHOW INDEX FROM <table>`

```
spanner> SHOW INDEX FROM Singers;
+---------+--------------+------------------------+-------------+-----------+------------------+-------------+
| Table   | Parent_table | Index_name             | Index_type  | Is_unique | Is_null_filtered | Index_state |
+---------+--------------+------------------------+-------------+-----------+------------------+-------------+
| Singers |              | PRIMARY_KEY            | PRIMARY_KEY | true      | false            | NULL        |
| Singers |              | SingersByFirstLastName | INDEX       | false     | false            | READ_WRITE  |
+---------+--------------+------------------------+-------------+-----------+------------------+-------------+
2 rows in set (0.18 sec)

spanner> SHOW INDEX FROM sch1.Singers;
+---------+--------------+----------------+-------------+-----------+------------------+-------------+
| Table   | Parent_table | Index_name     | Index_type  | Is_unique | Is_null_filtered | Index_state |
+---------+--------------+----------------+-------------+-----------+------------------+-------------+
| Singers |              | indexOnSingers | INDEX       | false     | false            | READ_WRITE  |
| Singers |              | PRIMARY_KEY    | PRIMARY_KEY | true      | false            | NULL        |
+---------+--------------+----------------+-------------+-----------+------------------+-------------+
2 rows in set (0.18 sec)
```
