### PR TITLE
Support GRAPH statement

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -82,7 +82,7 @@ type QueryStats struct {
 
 var (
 	// SQL
-	selectRe = regexp.MustCompile(`(?is)^(?:WITH|CALL|@{.+|SELECT)\s.+$`)
+	selectRe = regexp.MustCompile(`(?is)^(?:WITH|CALL|@{.+|SELECT|GRAPH)\s.+$`)
 
 	// DDL
 	createDatabaseRe = regexp.MustCompile(`(?is)^CREATE\s+DATABASE\s.+$`)

--- a/statement_test.go
+++ b/statement_test.go
@@ -508,6 +508,21 @@ func TestBuildStatement(t *testing.T) {
 			want:  &ExplainStatement{Explain: "WITH t1 AS (SELECT 1) SELECT * FROM t1"},
 		},
 		{
+			desc:  "GRAPH statement",
+			input: "GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id",
+			want:  &SelectStatement{Query: "GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id"},
+		},
+		{
+			desc:  "EXPLAIN GRAPH statement",
+			input: "EXPLAIN GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id",
+			want:  &ExplainStatement{Explain: "GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id"},
+		},
+		{
+			desc:  "EXPLAIN ANALYZE GRAPH statement",
+			input: "EXPLAIN ANALYZE GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id",
+			want:  &ExplainAnalyzeStatement{Query: "GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id"},
+		},
+		{
 			desc:  "DESCRIBE SELECT statement",
 			input: "DESCRIBE SELECT * FROM t1",
 			want:  &ExplainStatement{Explain: "SELECT * FROM t1"},


### PR DESCRIPTION
This PR adds `GRAPH`(and `EXPLAIN GRAPH`, `EXPLAIN ANALYZE GRAPH`) statement support into spanner-cli.

```
spanner> GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id;
+-----------+----+
| label     | id |
+-----------+----+
| [Account] | 7  |
| [Account] | 16 |
| [Account] | 20 |
| [Person]  | 1  |
| [Person]  | 2  |
| [Person]  | 3  |
+-----------+----+
6 rows in set (0.81 msecs)

spanner> EXPLAIN GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id;
+-----+----------------------------------------------------------------------------------------+
| ID  | Query_Execution_Plan                                                                   |
+-----+----------------------------------------------------------------------------------------+
|   0 | Serialize Result                                                                       |
|   1 | +- Union All                                                                           |
|   2 |    +- Union Input                                                                      |
|   3 |    |  +- Distributed Union (distribution_table: Account, split_ranges_aligned: false)  |
|   4 |    |     +- Local Distributed Union                                                    |
|   5 |    |        +- Compute                                                                 |
|   6 |    |           +- Table Scan (Full scan: true, Table: Account, scan_method: Automatic) |
|  12 |    +- Union Input                                                                      |
|  13 |       +- Distributed Union (distribution_table: Person, split_ranges_aligned: false)   |
|  14 |          +- Local Distributed Union                                                    |
|  15 |             +- Compute                                                                 |
|  16 |                +- Table Scan (Full scan: true, Table: Person, scan_method: Automatic)  |
+-----+----------------------------------------------------------------------------------------+
1 rows in set (0.17 sec)

spanner> EXPLAIN ANALYZE GRAPH FinGraph MATCH (n) RETURN LABELS(n) AS label, n.id;
+-----+----------------------------------------------------------------------------------------+---------------+------------+---------------+
| ID  | Query_Execution_Plan                                                                   | Rows_Returned | Executions | Total_Latency |
+-----+----------------------------------------------------------------------------------------+---------------+------------+---------------+
|   0 | Serialize Result                                                                       | 6             | 1          | 0.14 msecs    |
|   1 | +- Union All                                                                           | 6             | 1          | 0.1 msecs     |
|   2 |    +- Union Input                                                                      |               |            |               |
|   3 |    |  +- Distributed Union (distribution_table: Account, split_ranges_aligned: false)  | 3             | 1          | 0.08 msecs    |
|   4 |    |     +- Local Distributed Union                                                    | 3             | 1          | 0.06 msecs    |
|   5 |    |        +- Compute                                                                 |               |            |               |
|   6 |    |           +- Table Scan (Full scan: true, Table: Account, scan_method: Automatic) | 3             | 1          | 0.05 msecs    |
|  12 |    +- Union Input                                                                      |               |            |               |
|  13 |       +- Distributed Union (distribution_table: Person, split_ranges_aligned: false)   | 3             | 1          | 0.02 msecs    |
|  14 |          +- Local Distributed Union                                                    | 3             | 1          | 0.01 msecs    |
|  15 |             +- Compute                                                                 |               |            |               |
|  16 |                +- Table Scan (Full scan: true, Table: Person, scan_method: Automatic)  | 3             | 1          | 0.01 msecs    |
+-----+----------------------------------------------------------------------------------------+---------------+------------+---------------+
6 rows in set (5 msecs)
timestamp:            2024-08-02T08:53:38.967843+09:00
cpu time:             4.02 msecs
rows scanned:         6 rows
deleted rows scanned: 0 rows
optimizer version:    6
optimizer statistics: auto_20240730_19_06_39UTC
```

fixes #180 