### PR TITLE
Add --prompt2 and --no-prompt2

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -172,7 +172,7 @@ func TestReadInteractiveInput(t *testing.T) {
 				t.Fatalf("unexpected readline.NewEx() error: %v", err)
 			}
 
-			got, err := readInteractiveInput(rl, "")
+			got, err := readInteractiveInput(rl, "", "")
 			if err != nil && !tt.wantError {
 				t.Errorf("readInteractiveInput(%q) got error: %v", tt.input, err)
 			}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ type spannerOptions struct {
 	Verbose      bool   `short:"v" long:"verbose" description:"Display verbose output."`
 	Credential   string `long:"credential" description:"Use the specific credential file"`
 	Prompt       string `long:"prompt" description:"Set the prompt to the specified format"`
+	Prompt2      string `long:"prompt2" description:"Set the prompt2 to the specified format"`
+	NoPrompt2    bool   `long:"no-prompt2" description:"Set the prompt2 to empty"`
 	HistoryFile  string `long:"history" description:"Set the history file to the specified path"`
 	Priority     string `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
 	Role         string `long:"role" description:"Use the specific database role"`
@@ -96,7 +98,7 @@ func main() {
 		}
 	}
 
-	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority, opts.Role, opts.Endpoint, directedRead)
+	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.Prompt2, opts.HistoryFile, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority, opts.Role, opts.Endpoint, directedRead, opts.NoPrompt2)
 	if err != nil {
 		exitf("Failed to connect to Spanner: %v", err)
 	}


### PR DESCRIPTION
The default behavior is unchanged.

```
$ ./spanner-cli --project ${SPANNER_PROJECT} --instance ${SPANNER_INSTANCE} --database ${SPANNER_DATABASE}             
Connected.
spanner> SELECT 1 +
      -> 2;
```

`--prompt2` modifies multi-line prompt.

```
$ ./spanner-cli --project ${SPANNER_PROJECT} --instance ${SPANNER_INSTANCE} --database ${SPANNER_DATABASE} --prompt2='$ '
Connected.
spanner> SELECT 1 +
       $ 2;
```

`--no-promp2` sets prompt2 to empty.
```
$ ./spanner-cli --project ${SPANNER_PROJECT} --instance ${SPANNER_INSTANCE} --database ${SPANNER_DATABASE} --no-prompt2     
Connected.
spanner> SELECT 1 +
         2;
```

fixes #183 