### PR TITLE
(WIP) Add --prompt2 and print parser status(\R)

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -172,7 +172,7 @@ func TestReadInteractiveInput(t *testing.T) {
 				t.Fatalf("unexpected readline.NewEx() error: %v", err)
 			}
 
-			got, err := readInteractiveInput(rl, "")
+			got, err := readInteractiveInput(rl, "", "")
 			if err != nil && !tt.wantError {
 				t.Errorf("readInteractiveInput(%q) got error: %v", tt.input, err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go v0.112.2
 	cloud.google.com/go/spanner v1.59.0
-	github.com/apstndb/gsqlsep v0.0.0-20230324124551-0e8335710080
+	github.com/apstndb/gsqlsep v0.0.0-20240823174243-432be37d515a
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/google/go-cmp v0.6.0
 	github.com/jessevdk/go-flags v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -638,6 +638,10 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apstndb/gsqlsep v0.0.0-20230324124551-0e8335710080 h1:L1KrVddvtrBT7T2/408TOPu9xNr2I/OCJUUOugMezNk=
 github.com/apstndb/gsqlsep v0.0.0-20230324124551-0e8335710080/go.mod h1:NQogaK8AOkyzXEXMqGvc6hV0SKO8cUkcqqXJimyvTlw=
+github.com/apstndb/gsqlsep v0.0.0-20240823172307-f52ee6ff1135 h1:VYyKnlXnOsrGlYiQralTuig5cL+wCVVAawoZjT1Ic3E=
+github.com/apstndb/gsqlsep v0.0.0-20240823172307-f52ee6ff1135/go.mod h1:NQogaK8AOkyzXEXMqGvc6hV0SKO8cUkcqqXJimyvTlw=
+github.com/apstndb/gsqlsep v0.0.0-20240823174243-432be37d515a h1:9rutREITQVQSkSt2uoRr8ap6JA+k5i7NL1zRmJe621g=
+github.com/apstndb/gsqlsep v0.0.0-20240823174243-432be37d515a/go.mod h1:NQogaK8AOkyzXEXMqGvc6hV0SKO8cUkcqqXJimyvTlw=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/main.go
+++ b/main.go
@@ -33,20 +33,22 @@ type globalOptions struct {
 }
 
 type spannerOptions struct {
-	ProjectId    string `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
-	InstanceId   string `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID"`
-	DatabaseId   string `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
-	Execute      string `short:"e" long:"execute" description:"Execute SQL statement and quit."`
-	File         string `short:"f" long:"file" description:"Execute SQL statement from file and quit."`
-	Table        bool   `short:"t" long:"table" description:"Display output in table format for batch mode."`
-	Verbose      bool   `short:"v" long:"verbose" description:"Display verbose output."`
-	Credential   string `long:"credential" description:"Use the specific credential file"`
-	Prompt       string `long:"prompt" description:"Set the prompt to the specified format"`
-	HistoryFile  string `long:"history" description:"Set the history file to the specified path"`
-	Priority     string `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
-	Role         string `long:"role" description:"Use the specific database role"`
-	Endpoint     string `long:"endpoint" description:"Set the Spanner API endpoint (host:port)"`
-	DirectedRead string `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE"`
+	ProjectId    string  `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
+	InstanceId   string  `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID"`
+	DatabaseId   string  `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
+	Execute      string  `short:"e" long:"execute" description:"Execute SQL statement and quit."`
+	File         string  `short:"f" long:"file" description:"Execute SQL statement from file and quit."`
+	Table        bool    `short:"t" long:"table" description:"Display output in table format for batch mode."`
+	Verbose      bool    `short:"v" long:"verbose" description:"Display verbose output."`
+	Credential   string  `long:"credential" description:"Use the specific credential file"`
+	Prompt       string  `long:"prompt" description:"Set the prompt to the specified format"`
+	Prompt2      *string `long:"prompt2" description:"Set the prompt2 to the specified format"`
+	NoPrompt2    bool    `long:"no-prompt2" description:"Set the prompt2 to empty"`
+	HistoryFile  string  `long:"history" description:"Set the history file to the specified path"`
+	Priority     string  `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
+	Role         string  `long:"role" description:"Use the specific database role"`
+	Endpoint     string  `long:"endpoint" description:"Set the Spanner API endpoint (host:port)"`
+	DirectedRead string  `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE"`
 }
 
 func main() {
@@ -96,7 +98,7 @@ func main() {
 		}
 	}
 
-	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority, opts.Role, opts.Endpoint, directedRead)
+	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority, opts.Role, opts.Endpoint, directedRead, opts.Prompt2)
 	if err != nil {
 		exitf("Failed to connect to Spanner: %v", err)
 	}

--- a/separator.go
+++ b/separator.go
@@ -30,14 +30,15 @@ type inputStatement struct {
 	delim                    string
 }
 
-func separateInput(input string) []inputStatement {
+func separateInput(input string) ([]inputStatement, string) {
 	var result []inputStatement
-	for _, stmt := range gsqlsep.SeparateInputPreserveComments(input, delimiterVertical) {
+	stmts, status := gsqlsep.SeparateInputPreserveCommentsWithStatus(input, delimiterVertical)
+	for _, stmt := range stmts {
 		result = append(result, inputStatement{
 			statement:                stmt.Statement,
 			statementWithoutComments: stmt.StripComments().Statement,
 			delim:                    stmt.Terminator,
 		})
 	}
-	return result
+	return result, status.WaitingString
 }

--- a/separator_test.go
+++ b/separator_test.go
@@ -24,9 +24,10 @@ import (
 
 func TestSeparateInput(t *testing.T) {
 	for _, tt := range []struct {
-		desc  string
-		input string
-		want  []inputStatement
+		desc              string
+		input             string
+		want              []inputStatement
+		wantWaitingString string
 	}{
 		{
 			desc:  "single query",
@@ -269,6 +270,7 @@ func TestSeparateInput(t *testing.T) {
 					delim:                    delimiterUndefined,
 				},
 			},
+			wantWaitingString: `"`,
 		},
 		{
 			desc:  `totally incorrect query`,
@@ -280,6 +282,7 @@ func TestSeparateInput(t *testing.T) {
 					delim:                    delimiterUndefined,
 				},
 			},
+			wantWaitingString: `"""`,
 		},
 		{
 			desc:  `statement with multiple comments`,
@@ -304,8 +307,12 @@ func TestSeparateInput(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			got := separateInput(tt.input)
+			got, gotWaitingString := separateInput(tt.input)
 			if diff := cmp.Diff(tt.want, got, cmp.AllowUnexported(inputStatement{})); diff != "" {
+				t.Errorf("difference in statements: (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tt.wantWaitingString, gotWaitingString, cmp.AllowUnexported(inputStatement{})); diff != "" {
 				t.Errorf("difference in statements: (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
It is a prototype of supporting MySQL style multiline-query prompt and PostgreSQL's `%R` like prompt2 variable `\R`.
It relies to [latest update of gsqlsep](https://github.com/apstndb/gsqlsep/compare/29574a19d750dad6dd0c39aa886fbcaab87fd4b7..432be37d515a12c4665ca4aa963a6f4382dc750e).

The default of prompt2 is `\R>`, and `\R` is expanded to waiting string. (It is similar to MySQL behavior)

```
$ ./spanner-cli --project ${SPANNER_PROJECT} --instance ${SPANNER_INSTANCE} --database ${SPANNER_DATABASE}
Connected.
spanner> SELECT '
      '> ' "
      "> " `
      `> ` """
    """> """ '''
    '''> ''' /*
     */> */
      -> ^C

```

`--prompt2 ""` set prompt2 to empty

```
$ ./spanner-cli --project ${SPANNER_PROJECT} --instance ${SPANNER_INSTANCE} --database ${SPANNER_DATABASE} --prompt2 ""
Connected.
spanner> SELECT 1
         "
         "
         ^C
```

Current prompt2 implementation does automatic padding, but PostgreSQL doesn't do padding without [`%w`](https://www.postgresql.org/docs/current/app-psql.html#APP-PSQL-PROMPTING-W)

Caveats

> ```
> %w 
> Whitespace of the same width as the most recent output of PROMPT1. This can be used as a PROMPT2 setting, so that multi-line statements are aligned with the first line, but there is no visible secondary prompt.
> ```