### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Build stage
+FROM golang:1.23 as build
+WORKDIR /go/src/spanner-cli
+COPY . .
+RUN go mod download
+RUN CGO_ENABLED=0 go build -o /go/bin/spanner-cli
+
+# Final stage
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /go/bin/spanner-cli /
+ENTRYPOINT ["/spanner-cli"]

--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ go install github.com/cloudspannerecosystem/spanner-cli@latest
 go get -u github.com/cloudspannerecosystem/spanner-cli
 ```
 
-Or you can build a docker image and use it.
+Or you can build a docker image.
 
 ```
 git clone https://github.com/cloudspannerecosystem/spanner-cli.git
 cd spanner-cli
 docker build -t spanner-cli .
-docker run spanner-cli --help
 ```
 
 ## Usage
@@ -57,8 +56,20 @@ Help Options:
   -h, --help        Show this help message
 ```
 
+### Authentication
+
 Unless you specify a credential file with `--credential`, this tool uses [Application Default Credentials](https://cloud.google.com/docs/authentication/production?hl=en#providing_credentials_to_your_application) as credential source to connect to Spanner databases.  
+
 Please make sure to prepare your credential by `gcloud auth application-default login`.
+
+If you're running spanner-cli in docker container on your local machine, you have to pass local credentials to the container with the following command.
+
+```
+docker run -it \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/credentials.json \
+  -v $HOME/.config/gcloud/application_default_credentials.json:/tmp/credentials.json:ro \
+  spanner-cli --help
+```
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ go install github.com/cloudspannerecosystem/spanner-cli@latest
 go get -u github.com/cloudspannerecosystem/spanner-cli
 ```
 
-Or you can download the old binary from the [releases](https://github.com/cloudspannerecosystem/spanner-cli/releases).
+Or you can build a docker image and use it.
+
+```
+git clone https://github.com/cloudspannerecosystem/spanner-cli.git
+cd spanner-cli
+docker build -t spanner-cli .
+docker run spanner-cli --help
+```
 
 ## Usage
 


### PR DESCRIPTION
It needs some effort to publish the docker image (officially), so I added a Dockerfile so that users can use it for building the container image themselves.

Fix: https://github.com/cloudspannerecosystem/spanner-cli/issues/189