### PR TITLE
Add CLI flag `--skip-tls-verify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,23 +37,24 @@ Usage:
   spanner-cli [OPTIONS]
 
 spanner:
-  -p, --project=       (required) GCP Project ID. [$SPANNER_PROJECT_ID]
-  -i, --instance=      (required) Cloud Spanner Instance ID [$SPANNER_INSTANCE_ID]
-  -d, --database=      (required) Cloud Spanner Database ID. [$SPANNER_DATABASE_ID]
-  -e, --execute=       Execute SQL statement and quit.
-  -f, --file=          Execute SQL statement from file and quit.
-  -t, --table          Display output in table format for batch mode.
-  -v, --verbose        Display verbose output.
-      --credential=    Use the specific credential file
-      --prompt=        Set the prompt to the specified format
-      --history=       Set the history file to the specified path
-      --priority=      Set default request priority (HIGH|MEDIUM|LOW)
-      --role=          Use the specific database role
-      --directed-read= Directed read option (replica_location:replica_type).
-                       The replicat_type is optional and either READ_ONLY or READ_WRITE.
+  -p, --project=         (required) GCP Project ID. [$SPANNER_PROJECT_ID]
+  -i, --instance=        (required) Cloud Spanner Instance ID [$SPANNER_INSTANCE_ID]
+  -d, --database=        (required) Cloud Spanner Database ID. [$SPANNER_DATABASE_ID]
+  -e, --execute=         Execute SQL statement and quit.
+  -f, --file=            Execute SQL statement from file and quit.
+  -t, --table            Display output in table format for batch mode.
+  -v, --verbose          Display verbose output.
+      --credential=      Use the specific credential file
+      --prompt=          Set the prompt to the specified format
+      --history=         Set the history file to the specified path
+      --priority=        Set default request priority (HIGH|MEDIUM|LOW)
+      --role=            Use the specific database role
+      --endpoint=        Set the Spanner API endpoint (host:port)
+      --directed-read=   Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE
+      --skip-tls-verify  Insecurely skip TLS verify
 
 Help Options:
-  -h, --help        Show this help message
+  -h, --help             Show this help message
 ```
 
 ### Authentication

--- a/main.go
+++ b/main.go
@@ -33,20 +33,21 @@ type globalOptions struct {
 }
 
 type spannerOptions struct {
-	ProjectId    string `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
-	InstanceId   string `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID"`
-	DatabaseId   string `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
-	Execute      string `short:"e" long:"execute" description:"Execute SQL statement and quit."`
-	File         string `short:"f" long:"file" description:"Execute SQL statement from file and quit."`
-	Table        bool   `short:"t" long:"table" description:"Display output in table format for batch mode."`
-	Verbose      bool   `short:"v" long:"verbose" description:"Display verbose output."`
-	Credential   string `long:"credential" description:"Use the specific credential file"`
-	Prompt       string `long:"prompt" description:"Set the prompt to the specified format"`
-	HistoryFile  string `long:"history" description:"Set the history file to the specified path"`
-	Priority     string `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
-	Role         string `long:"role" description:"Use the specific database role"`
-	Endpoint     string `long:"endpoint" description:"Set the Spanner API endpoint (host:port)"`
-	DirectedRead string `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE"`
+	ProjectId     string `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
+	InstanceId    string `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID"`
+	DatabaseId    string `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
+	Execute       string `short:"e" long:"execute" description:"Execute SQL statement and quit."`
+	File          string `short:"f" long:"file" description:"Execute SQL statement from file and quit."`
+	Table         bool   `short:"t" long:"table" description:"Display output in table format for batch mode."`
+	Verbose       bool   `short:"v" long:"verbose" description:"Display verbose output."`
+	Credential    string `long:"credential" description:"Use the specific credential file"`
+	Prompt        string `long:"prompt" description:"Set the prompt to the specified format"`
+	HistoryFile   string `long:"history" description:"Set the history file to the specified path"`
+	Priority      string `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
+	Role          string `long:"role" description:"Use the specific database role"`
+	Endpoint      string `long:"endpoint" description:"Set the Spanner API endpoint (host:port)"`
+	DirectedRead  string `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE"`
+	SkipTLSVerify bool   `long:"skip-tls-verify" description:"Insecurely skip TLS verify"`
 }
 
 func main() {
@@ -96,7 +97,7 @@ func main() {
 		}
 	}
 
-	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority, opts.Role, opts.Endpoint, directedRead)
+	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority, opts.Role, opts.Endpoint, directedRead, opts.SkipTLSVerify)
 	if err != nil {
 		exitf("Failed to connect to Spanner: %v", err)
 	}


### PR DESCRIPTION
The `--endpoint` flag (added by https://github.com/cloudspannerecosystem/spanner-cli/pull/162) allows spanner-cli to connects to a custom API endpoint.

However, gRPC will only send credentials (specified by `--credentials` or env `GOOGLE_APPLICATION_CREDENTIALS`) when TLS is enabled. To ease some use cases during local testing, this pull request adds `--skip-tls-verify` which implicitly enables TLS while skipping certificate verification.