### PR TITLE
Implement --proto-descriptor-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,24 +37,25 @@ Usage:
   spanner-cli [OPTIONS]
 
 spanner:
-  -p, --project=         (required) GCP Project ID. [$SPANNER_PROJECT_ID]
-  -i, --instance=        (required) Cloud Spanner Instance ID [$SPANNER_INSTANCE_ID]
-  -d, --database=        (required) Cloud Spanner Database ID. [$SPANNER_DATABASE_ID]
-  -e, --execute=         Execute SQL statement and quit.
-  -f, --file=            Execute SQL statement from file and quit.
-  -t, --table            Display output in table format for batch mode.
-  -v, --verbose          Display verbose output.
-      --credential=      Use the specific credential file
-      --prompt=          Set the prompt to the specified format
-      --history=         Set the history file to the specified path
-      --priority=        Set default request priority (HIGH|MEDIUM|LOW)
-      --role=            Use the specific database role
-      --endpoint=        Set the Spanner API endpoint (host:port)
-      --directed-read=   Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE
-      --skip-tls-verify  Insecurely skip TLS verify
+  -p, --project=               (required) GCP Project ID. [$SPANNER_PROJECT_ID]
+  -i, --instance=              (required) Cloud Spanner Instance ID [$SPANNER_INSTANCE_ID]
+  -d, --database=              (required) Cloud Spanner Database ID. [$SPANNER_DATABASE_ID]
+  -e, --execute=               Execute SQL statement and quit.
+  -f, --file=                  Execute SQL statement from file and quit.
+  -t, --table                  Display output in table format for batch mode.
+  -v, --verbose                Display verbose output.
+      --credential=            Use the specific credential file
+      --prompt=                Set the prompt to the specified format
+      --history=               Set the history file to the specified path
+      --priority=              Set default request priority (HIGH|MEDIUM|LOW)
+      --role=                  Use the specific database role
+      --endpoint=              Set the Spanner API endpoint (host:port)
+      --directed-read=         Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE
+      --skip-tls-verify        Insecurely skip TLS verify
+      --proto-descriptor-file= Path of a file that contains a protobuf-serialized google.protobuf.FileDescriptorSet message to use in this invocation.
 
 Help Options:
-  -h, --help             Show this help message
+  -h, --help                   Show this help message
 ```
 
 ### Authentication

--- a/cli.go
+++ b/cli.go
@@ -82,8 +82,8 @@ type command struct {
 func NewCli(projectId, instanceId, databaseId, prompt, historyFile string, credential []byte,
 	inStream io.ReadCloser, outStream, errStream io.Writer, verbose bool,
 	priority pb.RequestOptions_Priority, role, endpoint string, directedRead *pb.DirectedReadOptions,
-	skipTLSVerify bool, protoDescriptorFileContent []byte) (*Cli, error) {
-	session, err := createSession(projectId, instanceId, databaseId, credential, priority, role, endpoint, directedRead, skipTLSVerify, protoDescriptorFileContent)
+	skipTLSVerify bool, protoDescriptor []byte) (*Cli, error) {
+	session, err := createSession(projectId, instanceId, databaseId, credential, priority, role, endpoint, directedRead, skipTLSVerify, protoDescriptor)
 	if err != nil {
 		return nil, err
 	}

--- a/cli.go
+++ b/cli.go
@@ -156,7 +156,8 @@ func (c *Cli) RunInteractive() int {
 		}
 
 		if s, ok := stmt.(*UseStatement); ok {
-			newSession, err := createSession(c.Session.projectId, c.Session.instanceId, s.Database, c.Credential, c.Priority, s.Role, c.Endpoint, c.Session.directedRead, c.SkipTLSVerify, nil)
+			newSession, err := createSession(c.Session.projectId, c.Session.instanceId, s.Database, c.Credential, c.Priority,
+				s.Role, c.Endpoint, c.Session.directedRead, c.SkipTLSVerify, c.Session.protoDescriptorFileContent)
 			if err != nil {
 				c.PrintInteractiveError(err)
 				continue

--- a/cli.go
+++ b/cli.go
@@ -157,7 +157,7 @@ func (c *Cli) RunInteractive() int {
 
 		if s, ok := stmt.(*UseStatement); ok {
 			newSession, err := createSession(c.Session.projectId, c.Session.instanceId, s.Database, c.Credential, c.Priority,
-				s.Role, c.Endpoint, c.Session.directedRead, c.SkipTLSVerify, c.Session.protoDescriptorFileContent)
+				s.Role, c.Endpoint, c.Session.directedRead, c.SkipTLSVerify, c.Session.protoDescriptor)
 			if err != nil {
 				c.PrintInteractiveError(err)
 				continue
@@ -321,7 +321,7 @@ func (c *Cli) getInterpolatedPrompt() string {
 
 func createSession(projectId string, instanceId string, databaseId string, credential []byte,
 	priority pb.RequestOptions_Priority, role string, endpoint string, directedRead *pb.DirectedReadOptions,
-	skipTLSVerify bool, protoDescriptorFileContent []byte) (*Session, error) {
+	skipTLSVerify bool, protoDescriptor []byte) (*Session, error) {
 	var opts []option.ClientOption
 	if credential != nil {
 		opts = append(opts, option.WithCredentialsJSON(credential))
@@ -333,7 +333,7 @@ func createSession(projectId string, instanceId string, databaseId string, crede
 		creds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
 		opts = append(opts, option.WithGRPCDialOption(grpc.WithTransportCredentials(creds)))
 	}
-	return NewSession(projectId, instanceId, databaseId, priority, role, directedRead, protoDescriptorFileContent, opts...)
+	return NewSession(projectId, instanceId, databaseId, priority, role, directedRead, protoDescriptor, opts...)
 }
 
 func readInteractiveInput(rl *readline.Instance, prompt string) (*inputStatement, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/cloudspannerecosystem/spanner-cli
 
-go 1.21
-
-toolchain go1.23.2
+go 1.19
 
 require (
 	cloud.google.com/go v0.113.0

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,14 @@
 module github.com/cloudspannerecosystem/spanner-cli
 
-go 1.19
+go 1.21
+
+toolchain go1.23.2
 
 require (
 	cloud.google.com/go v0.113.0
 	cloud.google.com/go/spanner v1.62.0
 	github.com/apstndb/gsqlsep v0.0.0-20230324124551-0e8335710080
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
-	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.6.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -796,6 +796,7 @@ github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/enterprise-certificate-proxy v0.1.0/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/enterprise-certificate-proxy v0.2.0/go.mod h1:8C0jb7/mgJe/9KK8Lm7X9ctZC2t60YyIpYEI16jx0Qg=
@@ -894,6 +895,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xlab/treeprint v1.0.1-0.20200715141336-10e0bc383e01 h1:uk2OUothYXw3JM+BEogrZA9AJ8g6ti77HjdAcTu3Gz8=
 github.com/xlab/treeprint v1.0.1-0.20200715141336-10e0bc383e01/go.mod h1:IoImgRak9i3zJyuxOKUP1v4UZd1tMoKkq/Cimt1uhCg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -923,6 +925,7 @@ go.opentelemetry.io/otel v1.24.0/go.mod h1:W7b9Ozg4nkF5tWI5zsXkaKKDjdVjpD4oAt9Qi
 go.opentelemetry.io/otel/metric v1.24.0 h1:6EhoGWWK28x1fbpA4tYTOWBkPefTDQnb8WSGXlc88kI=
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/sdk v1.24.0 h1:YMPPDNymmQN3ZgczicBY3B6sf9n62Dlj9pWD3ucgoDw=
+go.opentelemetry.io/otel/sdk v1.24.0/go.mod h1:KVrIYw6tEubO9E96HQpcmpTKDVn9gdv35HoYiQWGDFg=
 go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y1YELI=
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=

--- a/go.sum
+++ b/go.sum
@@ -796,7 +796,6 @@ github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/enterprise-certificate-proxy v0.1.0/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/enterprise-certificate-proxy v0.2.0/go.mod h1:8C0jb7/mgJe/9KK8Lm7X9ctZC2t60YyIpYEI16jx0Qg=
@@ -895,7 +894,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xlab/treeprint v1.0.1-0.20200715141336-10e0bc383e01 h1:uk2OUothYXw3JM+BEogrZA9AJ8g6ti77HjdAcTu3Gz8=
 github.com/xlab/treeprint v1.0.1-0.20200715141336-10e0bc383e01/go.mod h1:IoImgRak9i3zJyuxOKUP1v4UZd1tMoKkq/Cimt1uhCg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -925,7 +923,6 @@ go.opentelemetry.io/otel v1.24.0/go.mod h1:W7b9Ozg4nkF5tWI5zsXkaKKDjdVjpD4oAt9Qi
 go.opentelemetry.io/otel/metric v1.24.0 h1:6EhoGWWK28x1fbpA4tYTOWBkPefTDQnb8WSGXlc88kI=
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/sdk v1.24.0 h1:YMPPDNymmQN3ZgczicBY3B6sf9n62Dlj9pWD3ucgoDw=
-go.opentelemetry.io/otel/sdk v1.24.0/go.mod h1:KVrIYw6tEubO9E96HQpcmpTKDVn9gdv35HoYiQWGDFg=
 go.opentelemetry.io/otel/trace v1.24.0 h1:CsKnnL4dUAr/0llH9FKuc698G04IrpWV0MQA/Y1YELI=
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=

--- a/integration_test.go
+++ b/integration_test.go
@@ -86,7 +86,7 @@ func setup(t *testing.T, ctx context.Context, dmls []string) (*Session, string, 
 	if testCredential != "" {
 		options = append(options, option.WithCredentialsJSON([]byte(testCredential)))
 	}
-	session, err := NewSession(testProjectId, testInstanceId, testDatabaseId, pb.RequestOptions_PRIORITY_UNSPECIFIED, "", nil, options...)
+	session, err := NewSession(testProjectId, testInstanceId, testDatabaseId, pb.RequestOptions_PRIORITY_UNSPECIFIED, "", nil, nil, options...)
 	if err != nil {
 		t.Fatalf("failed to create test session: err=%s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -99,19 +99,18 @@ func main() {
 	}
 
 	// Don't need to unmarshal into descriptorpb.FileDescriptorSet because the UpdateDDL API just accepts []byte.
-	var protoDescriptorFileContent []byte
+	var protoDescriptor []byte
 	if opts.ProtoDescriptorFile != "" {
 		var err error
-		b, err := os.ReadFile(opts.ProtoDescriptorFile)
+		protoDescriptor, err = os.ReadFile(opts.ProtoDescriptorFile)
 		if err != nil {
 			exitf("Failed to read proto descriptor file: %v\n", err)
 		}
-		protoDescriptorFileContent = b
 	}
 
 	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred,
 		os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority, opts.Role, opts.Endpoint, directedRead,
-		opts.SkipTLSVerify, protoDescriptorFileContent)
+		opts.SkipTLSVerify, protoDescriptor)
 	if err != nil {
 		exitf("Failed to connect to Spanner: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -33,21 +33,22 @@ type globalOptions struct {
 }
 
 type spannerOptions struct {
-	ProjectId     string `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
-	InstanceId    string `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID"`
-	DatabaseId    string `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
-	Execute       string `short:"e" long:"execute" description:"Execute SQL statement and quit."`
-	File          string `short:"f" long:"file" description:"Execute SQL statement from file and quit."`
-	Table         bool   `short:"t" long:"table" description:"Display output in table format for batch mode."`
-	Verbose       bool   `short:"v" long:"verbose" description:"Display verbose output."`
-	Credential    string `long:"credential" description:"Use the specific credential file"`
-	Prompt        string `long:"prompt" description:"Set the prompt to the specified format"`
-	HistoryFile   string `long:"history" description:"Set the history file to the specified path"`
-	Priority      string `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
-	Role          string `long:"role" description:"Use the specific database role"`
-	Endpoint      string `long:"endpoint" description:"Set the Spanner API endpoint (host:port)"`
-	DirectedRead  string `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE"`
-	SkipTLSVerify bool   `long:"skip-tls-verify" description:"Insecurely skip TLS verify"`
+	ProjectId           string `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
+	InstanceId          string `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID"`
+	DatabaseId          string `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
+	Execute             string `short:"e" long:"execute" description:"Execute SQL statement and quit."`
+	File                string `short:"f" long:"file" description:"Execute SQL statement from file and quit."`
+	Table               bool   `short:"t" long:"table" description:"Display output in table format for batch mode."`
+	Verbose             bool   `short:"v" long:"verbose" description:"Display verbose output."`
+	Credential          string `long:"credential" description:"Use the specific credential file"`
+	Prompt              string `long:"prompt" description:"Set the prompt to the specified format"`
+	HistoryFile         string `long:"history" description:"Set the history file to the specified path"`
+	Priority            string `long:"priority" description:"Set default request priority (HIGH|MEDIUM|LOW)"`
+	Role                string `long:"role" description:"Use the specific database role"`
+	Endpoint            string `long:"endpoint" description:"Set the Spanner API endpoint (host:port)"`
+	DirectedRead        string `long:"directed-read" description:"Directed read option (replica_location:replica_type). The replicat_type is optional and either READ_ONLY or READ_WRITE"`
+	SkipTLSVerify       bool   `long:"skip-tls-verify" description:"Insecurely skip TLS verify"`
+	ProtoDescriptorFile string `long:"proto-descriptor-file" description:"Path of a file that contains a protobuf-serialized google.protobuf.FileDescriptorSet message to use in this invocation."`
 }
 
 func main() {
@@ -97,7 +98,20 @@ func main() {
 		}
 	}
 
-	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred, os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority, opts.Role, opts.Endpoint, directedRead, opts.SkipTLSVerify)
+	// Don't need to unmarshal into descriptorpb.FileDescriptorSet because the UpdateDDL API just accepts []byte.
+	var protoDescriptorFileContent []byte
+	if opts.ProtoDescriptorFile != "" {
+		var err error
+		b, err := os.ReadFile(opts.ProtoDescriptorFile)
+		if err != nil {
+			exitf("Failed to read proto descriptor file: %v\n", err)
+		}
+		protoDescriptorFileContent = b
+	}
+
+	cli, err := NewCli(opts.ProjectId, opts.InstanceId, opts.DatabaseId, opts.Prompt, opts.HistoryFile, cred,
+		os.Stdin, os.Stdout, os.Stderr, opts.Verbose, priority, opts.Role, opts.Endpoint, directedRead,
+		opts.SkipTLSVerify, protoDescriptorFileContent)
 	if err != nil {
 		exitf("Failed to connect to Spanner: %v", err)
 	}

--- a/session.go
+++ b/session.go
@@ -47,17 +47,18 @@ var defaultClientOpts = []option.ClientOption{
 const defaultPriority = pb.RequestOptions_PRIORITY_MEDIUM
 
 type Session struct {
-	projectId       string
-	instanceId      string
-	databaseId      string
-	client          *spanner.Client
-	adminClient     *adminapi.DatabaseAdminClient
-	clientConfig    spanner.ClientConfig
-	clientOpts      []option.ClientOption
-	defaultPriority pb.RequestOptions_Priority
-	directedRead    *pb.DirectedReadOptions
-	tc              *transactionContext
-	tcMutex         sync.Mutex // Guard a critical section for transaction.
+	projectId                  string
+	instanceId                 string
+	databaseId                 string
+	client                     *spanner.Client
+	adminClient                *adminapi.DatabaseAdminClient
+	clientConfig               spanner.ClientConfig
+	clientOpts                 []option.ClientOption
+	defaultPriority            pb.RequestOptions_Priority
+	directedRead               *pb.DirectedReadOptions
+	tc                         *transactionContext
+	tcMutex                    sync.Mutex // Guard a critical section for transaction.
+	protoDescriptorFileContent []byte
 }
 
 type transactionContext struct {
@@ -68,7 +69,8 @@ type transactionContext struct {
 	roTxn         *spanner.ReadOnlyTransaction
 }
 
-func NewSession(projectId string, instanceId string, databaseId string, priority pb.RequestOptions_Priority, role string, directedRead *pb.DirectedReadOptions, opts ...option.ClientOption) (*Session, error) {
+func NewSession(projectId string, instanceId string, databaseId string, priority pb.RequestOptions_Priority, role string, directedRead *pb.DirectedReadOptions,
+	protoDescriptorFileContent []byte, opts ...option.ClientOption) (*Session, error) {
 	ctx := context.Background()
 	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectId, instanceId, databaseId)
 	clientConfig := defaultClientConfig
@@ -90,15 +92,16 @@ func NewSession(projectId string, instanceId string, databaseId string, priority
 	}
 
 	session := &Session{
-		projectId:       projectId,
-		instanceId:      instanceId,
-		databaseId:      databaseId,
-		client:          client,
-		clientConfig:    clientConfig,
-		clientOpts:      opts,
-		adminClient:     adminClient,
-		defaultPriority: priority,
-		directedRead:    directedRead,
+		projectId:                  projectId,
+		instanceId:                 instanceId,
+		databaseId:                 databaseId,
+		client:                     client,
+		clientConfig:               clientConfig,
+		clientOpts:                 opts,
+		adminClient:                adminClient,
+		defaultPriority:            priority,
+		directedRead:               directedRead,
+		protoDescriptorFileContent: protoDescriptorFileContent,
 	}
 	go session.startHeartbeat()
 

--- a/session.go
+++ b/session.go
@@ -47,18 +47,18 @@ var defaultClientOpts = []option.ClientOption{
 const defaultPriority = pb.RequestOptions_PRIORITY_MEDIUM
 
 type Session struct {
-	projectId                  string
-	instanceId                 string
-	databaseId                 string
-	client                     *spanner.Client
-	adminClient                *adminapi.DatabaseAdminClient
-	clientConfig               spanner.ClientConfig
-	clientOpts                 []option.ClientOption
-	defaultPriority            pb.RequestOptions_Priority
-	directedRead               *pb.DirectedReadOptions
-	tc                         *transactionContext
-	tcMutex                    sync.Mutex // Guard a critical section for transaction.
-	protoDescriptorFileContent []byte
+	projectId       string
+	instanceId      string
+	databaseId      string
+	client          *spanner.Client
+	adminClient     *adminapi.DatabaseAdminClient
+	clientConfig    spanner.ClientConfig
+	clientOpts      []option.ClientOption
+	defaultPriority pb.RequestOptions_Priority
+	directedRead    *pb.DirectedReadOptions
+	tc              *transactionContext
+	tcMutex         sync.Mutex // Guard a critical section for transaction.
+	protoDescriptor []byte
 }
 
 type transactionContext struct {
@@ -70,7 +70,7 @@ type transactionContext struct {
 }
 
 func NewSession(projectId string, instanceId string, databaseId string, priority pb.RequestOptions_Priority, role string, directedRead *pb.DirectedReadOptions,
-	protoDescriptorFileContent []byte, opts ...option.ClientOption) (*Session, error) {
+	protoDescriptor []byte, opts ...option.ClientOption) (*Session, error) {
 	ctx := context.Background()
 	dbPath := fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectId, instanceId, databaseId)
 	clientConfig := defaultClientConfig
@@ -92,16 +92,16 @@ func NewSession(projectId string, instanceId string, databaseId string, priority
 	}
 
 	session := &Session{
-		projectId:                  projectId,
-		instanceId:                 instanceId,
-		databaseId:                 databaseId,
-		client:                     client,
-		clientConfig:               clientConfig,
-		clientOpts:                 opts,
-		adminClient:                adminClient,
-		defaultPriority:            priority,
-		directedRead:               directedRead,
-		protoDescriptorFileContent: protoDescriptorFileContent,
+		projectId:       projectId,
+		instanceId:      instanceId,
+		databaseId:      databaseId,
+		client:          client,
+		clientConfig:    clientConfig,
+		clientOpts:      opts,
+		adminClient:     adminClient,
+		defaultPriority: priority,
+		directedRead:    directedRead,
+		protoDescriptor: protoDescriptor,
 	}
 	go session.startHeartbeat()
 

--- a/session_test.go
+++ b/session_test.go
@@ -66,7 +66,7 @@ func TestRequestPriority(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			defer recorder.flush()
 
-			session, err := NewSession("project", "instance", "database", test.sessionPriority, "role", nil, option.WithGRPCConn(conn))
+			session, err := NewSession("project", "instance", "database", test.sessionPriority, "role", nil, nil, option.WithGRPCConn(conn))
 			if err != nil {
 				t.Fatalf("failed to create spanner-cli session: %v", err)
 			}

--- a/statement.go
+++ b/statement.go
@@ -407,7 +407,7 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 		Database:   session.DatabasePath(),
 		Statements: ddls,
 		// There is no problem to send ProtoDescriptors with any DDL statements
-		ProtoDescriptors: session.protoDescriptorFileContent,
+		ProtoDescriptors: session.protoDescriptor,
 	})
 	if err != nil {
 		return nil, err

--- a/statement.go
+++ b/statement.go
@@ -406,7 +406,7 @@ func executeDdlStatements(ctx context.Context, session *Session, ddls []string) 
 	op, err := session.adminClient.UpdateDatabaseDdl(ctx, &adminpb.UpdateDatabaseDdlRequest{
 		Database:   session.DatabasePath(),
 		Statements: ddls,
-		// There is no problem to send ProtoDescriptors to any DDL statements
+		// There is no problem to send ProtoDescriptors with any DDL statements
 		ProtoDescriptors: session.protoDescriptorFileContent,
 	})
 	if err != nil {

--- a/statement.go
+++ b/statement.go
@@ -404,8 +404,9 @@ func (s *BulkDdlStatement) Execute(ctx context.Context, session *Session) (*Resu
 
 func executeDdlStatements(ctx context.Context, session *Session, ddls []string) (*Result, error) {
 	op, err := session.adminClient.UpdateDatabaseDdl(ctx, &adminpb.UpdateDatabaseDdlRequest{
-		Database:         session.DatabasePath(),
-		Statements:       ddls,
+		Database:   session.DatabasePath(),
+		Statements: ddls,
+		// There is no problem to send ProtoDescriptors to any DDL statements
 		ProtoDescriptors: session.protoDescriptorFileContent,
 	})
 	if err != nil {

--- a/statement.go
+++ b/statement.go
@@ -404,8 +404,9 @@ func (s *BulkDdlStatement) Execute(ctx context.Context, session *Session) (*Resu
 
 func executeDdlStatements(ctx context.Context, session *Session, ddls []string) (*Result, error) {
 	op, err := session.adminClient.UpdateDatabaseDdl(ctx, &adminpb.UpdateDatabaseDdlRequest{
-		Database:   session.DatabasePath(),
-		Statements: ddls,
+		Database:         session.DatabasePath(),
+		Statements:       ddls,
+		ProtoDescriptors: session.protoDescriptorFileContent,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR implements `--proto-descriptor-file` option with `USE` statement compatibility.

```
$ go run ./ --database apstndb-sampledb3 --proto-descriptor-file order_descriptors.pb
Connected.
spanner> ALTER PROTO BUNDLE INSERT (`examples.shipping.OrderHistory`);
Query OK, 0 rows affected (11.11 sec)

spanner> USE apstndb-sampledb-with-data-idx;
spanner> ALTER PROTO BUNDLE INSERT (`examples.shipping.OrderHistory`);
Query OK, 0 rows affected (9.23 sec)
```

fixes #174 