### PR TITLE
replace `io/ioutil` with `io`, `os` package

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -46,15 +45,18 @@ func TestBuildCommands(t *testing.T) {
 	}{
 		{Input: `SELECT * FROM t1;`, Expected: []*command{{&SelectStatement{"SELECT * FROM t1"}, false}}},
 		{Input: `CREATE TABLE t1;`, Expected: []*command{{&BulkDdlStatement{[]string{"CREATE TABLE t1"}}, false}}},
-		{Input: `CREATE TABLE t1(pk INT64) PRIMARY KEY(pk); ALTER TABLE t1 ADD COLUMN col INT64; CREATE INDEX i1 ON t1(col); DROP INDEX i1; DROP TABLE t1;`,
+		{
+			Input: `CREATE TABLE t1(pk INT64) PRIMARY KEY(pk); ALTER TABLE t1 ADD COLUMN col INT64; CREATE INDEX i1 ON t1(col); DROP INDEX i1; DROP TABLE t1;`,
 			Expected: []*command{{&BulkDdlStatement{[]string{
 				"CREATE TABLE t1(pk INT64) PRIMARY KEY(pk)",
 				"ALTER TABLE t1 ADD COLUMN col INT64",
 				"CREATE INDEX i1 ON t1(col)",
 				"DROP INDEX i1",
 				"DROP TABLE t1",
-			}}, false}}},
-		{Input: `CREATE TABLE t1(pk INT64) PRIMARY KEY(pk);
+			}}, false}},
+		},
+		{
+			Input: `CREATE TABLE t1(pk INT64) PRIMARY KEY(pk);
                 CREATE TABLE t2(pk INT64) PRIMARY KEY(pk);
                 SELECT * FROM t1\G
                 DROP TABLE t1;
@@ -65,7 +67,8 @@ func TestBuildCommands(t *testing.T) {
 				{&SelectStatement{"SELECT * FROM t1"}, true},
 				{&BulkDdlStatement{[]string{"DROP TABLE t1", "DROP TABLE t2"}}, false},
 				{&SelectStatement{"SELECT 1"}, false},
-			}},
+			},
+		},
 		{
 			Input: `
 			CREATE TABLE t1(pk INT64 /* NOT NULL*/, col INT64) PRIMARY KEY(pk);
@@ -79,7 +82,8 @@ func TestBuildCommands(t *testing.T) {
 				{&DmlStatement{"UPDATE t1 SET col = /* pk + */ col + 1 WHERE TRUE"}, false},
 				{&DmlStatement{"DELETE t1 WHERE TRUE /* AND pk = 1 */"}, false},
 				{&SelectStatement{"SELECT 0x1/**/A"}, false},
-			}},
+			},
+		},
 		{
 			// spanner-cli don't permit empty statements.
 			Input:       `SELECT 1; /* comment */; SELECT 2`,
@@ -94,7 +98,8 @@ func TestBuildCommands(t *testing.T) {
 			Input: `SELECT 1; /* comment */`,
 			Expected: []*command{
 				{&SelectStatement{"SELECT 1"}, false},
-			}},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -164,9 +169,9 @@ func TestReadInteractiveInput(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			rl, err := readline.NewEx(&readline.Config{
-				Stdin:  ioutil.NopCloser(strings.NewReader(tt.input)),
-				Stdout: ioutil.Discard,
-				Stderr: ioutil.Discard,
+				Stdin:  io.NopCloser(strings.NewReader(tt.input)),
+				Stdout: io.Discard,
+				Stderr: io.Discard,
 			})
 			if err != nil {
 				t.Fatalf("unexpected readline.NewEx() error: %v", err)
@@ -189,8 +194,8 @@ func TestPrintResult(t *testing.T) {
 		result := &Result{
 			ColumnNames: []string{"foo", "bar"},
 			Rows: []Row{
-				Row{[]string{"1", "2"}},
-				Row{[]string{"3", "4"}},
+				{[]string{"1", "2"}},
+				{[]string{"3", "4"}},
 			},
 			IsMutation: false,
 		}
@@ -216,8 +221,8 @@ func TestPrintResult(t *testing.T) {
 		result := &Result{
 			ColumnNames: []string{"foo", "bar"},
 			Rows: []Row{
-				Row{[]string{"1", "2"}},
-				Row{[]string{"3", "4"}},
+				{[]string{"1", "2"}},
+				{[]string{"3", "4"}},
 			},
 			IsMutation: false,
 		}
@@ -243,8 +248,8 @@ bar: 4
 		result := &Result{
 			ColumnNames: []string{"foo", "bar"},
 			Rows: []Row{
-				Row{[]string{"1", "2"}},
-				Row{[]string{"3", "4"}},
+				{[]string{"1", "2"}},
+				{[]string{"3", "4"}},
 			},
 			IsMutation: false,
 		}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -119,13 +119,13 @@ func main() {
 	if opts.Execute != "" {
 		input = opts.Execute
 	} else if opts.File == "-" {
-		b, err := ioutil.ReadAll(os.Stdin)
+		b, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			exitf("Read from stdin failed: %v", err)
 		}
 		input = string(b)
 	} else if opts.File != "" {
-		b, err := ioutil.ReadFile(opts.File)
+		b, err := os.ReadFile(opts.File)
 		if err != nil {
 			exitf("Read from file %v failed: %v", opts.File, err)
 		}
@@ -182,13 +182,13 @@ func readCredentialFile(filepath string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 func readStdin() (string, error) {
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
-		b, err := ioutil.ReadAll(os.Stdin)
+		b, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return "", err
 		}

--- a/query_plan_test.go
+++ b/query_plan_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -67,7 +67,8 @@ func TestRenderTreeUsingTestdataPlans(t *testing.T) {
 					ID:   7,
 					Text: "                  +- Index Scan (Index: SingersByFirstLastName)",
 				},
-			}},
+			},
+		},
 		{
 			/*
 				Original Query:
@@ -107,7 +108,8 @@ func TestRenderTreeUsingTestdataPlans(t *testing.T) {
 					ID:   9,
 					Text: "         +- Index Scan (Full scan: true, Index: SongsBySingerAlbumSongNameDesc)",
 				},
-			}},
+			},
+		},
 		{
 			/*
 				Original Query: https://cloud.google.com/spanner/docs/query-execution-operators?hl=en#array_subqueries
@@ -158,7 +160,8 @@ func TestRenderTreeUsingTestdataPlans(t *testing.T) {
 					ID:   11,
 					Text: "                  +- Index Scan (Index: ConcertsBySingerId)",
 				},
-			}},
+			},
+		},
 		{
 			/*
 				Original Query: https://cloud.google.com/spanner/docs/query-execution-operators?hl=en#scalar_subqueries
@@ -219,7 +222,8 @@ func TestRenderTreeUsingTestdataPlans(t *testing.T) {
 					ID:   16,
 					Text: "                        +- Table Scan (Full scan: true, Table: Songs)",
 				},
-			}},
+			},
+		},
 		{
 			/*
 				Original Query:
@@ -367,7 +371,7 @@ func TestRenderTreeUsingTestdataPlans(t *testing.T) {
 		},
 	} {
 		t.Run(test.title, func(t *testing.T) {
-			b, err := ioutil.ReadFile(test.file)
+			b, err := os.ReadFile(test.file)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -480,7 +484,8 @@ func TestRenderTreeWithStats(t *testing.T) {
 					Execution:    "1",
 					LatencyTotal: "1 msec",
 				},
-			}},
+			},
+		},
 	} {
 		t.Run(test.title, func(t *testing.T) {
 			tree := BuildQueryPlanTree(test.plan, 0)
@@ -494,13 +499,15 @@ func TestRenderTreeWithStats(t *testing.T) {
 		})
 	}
 }
+
 func TestNodeString(t *testing.T) {
 	for _, test := range []struct {
 		title string
 		node  *Node
 		want  string
 	}{
-		{"Distributed Union with call_type=Local",
+		{
+			"Distributed Union with call_type=Local",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Distributed Union",
 				Metadata: mustNewStruct(map[string]interface{}{
@@ -509,7 +516,8 @@ func TestNodeString(t *testing.T) {
 				}),
 			}}, "Local Distributed Union",
 		},
-		{"Scan with scan_type=IndexScan and Full scan=true",
+		{
+			"Scan with scan_type=IndexScan and Full scan=true",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Scan",
 				Metadata: mustNewStruct(map[string]interface{}{
@@ -517,44 +525,55 @@ func TestNodeString(t *testing.T) {
 					"scan_target": "SongsBySongName",
 					"Full scan":   "true",
 				}),
-			}}, "Index Scan (Full scan: true, Index: SongsBySongName)"},
-		{"Scan with scan_type=TableScan",
+			}}, "Index Scan (Full scan: true, Index: SongsBySongName)",
+		},
+		{
+			"Scan with scan_type=TableScan",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Scan",
 				Metadata: mustNewStruct(map[string]interface{}{
 					"scan_type":   "TableScan",
 					"scan_target": "Songs",
 				}),
-			}}, "Table Scan (Table: Songs)"},
-		{"Scan with scan_type=BatchScan",
+			}}, "Table Scan (Table: Songs)",
+		},
+		{
+			"Scan with scan_type=BatchScan",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Scan",
 				Metadata: mustNewStruct(map[string]interface{}{
 					"scan_type":   "BatchScan",
 					"scan_target": "$v2",
 				}),
-			}}, "Batch Scan (Batch: $v2)"},
-		{"Sort Limit with call_type=Local",
+			}}, "Batch Scan (Batch: $v2)",
+		},
+		{
+			"Sort Limit with call_type=Local",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Sort Limit",
 				Metadata: mustNewStruct(map[string]interface{}{
 					"call_type": "Local",
 				}),
-			}}, "Local Sort Limit"},
-		{"Sort Limit with call_type=Global",
+			}}, "Local Sort Limit",
+		},
+		{
+			"Sort Limit with call_type=Global",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Sort Limit",
 				Metadata: mustNewStruct(map[string]interface{}{
 					"call_type": "Global",
 				}),
-			}}, "Global Sort Limit"},
-		{"Aggregate with iterator_type=Stream",
+			}}, "Global Sort Limit",
+		},
+		{
+			"Aggregate with iterator_type=Stream",
 			&Node{PlanNode: &spanner.PlanNode{
 				DisplayName: "Aggregate",
 				Metadata: mustNewStruct(map[string]interface{}{
 					"iterator_type": "Stream",
 				}),
-			}}, "Stream Aggregate"},
+			}}, "Stream Aggregate",
+		},
 	} {
 		if got := test.node.String(); got != test.want {
 			t.Errorf("%s: node.String() = %q but want %q", test.title, got, test.want)


### PR DESCRIPTION
## What

SSIA

## Why
As you may know, `io/ioutil` package is deprecated now.

> Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.
> https://pkg.go.dev/io/ioutil