### PR TITLE
Add transaction-level isolation level setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ and `{}` for a mutually exclusive keyword.
 | Show Query Result Shape | `DESCRIBE SELECT ...;` | |
 | Show DML Result Shape | `DESCRIBE {INSERT\|UPDATE\|DELETE} ... THEN RETURN ...;` | |
 | Start a new query optimizer statistics package construction | `ANALYZE;` | |
-| Start Read-Write Transaction | `BEGIN [RW] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <tag>];` | See [Request Priority](#request-priority) for details on the priority. The tag you set is used as both transaction tag and request tag. See also [Transaction Tags and Request Tags](#transaction-tags-and-request-tags).|
+| Start Read-Write Transaction | `BEGIN [RW] [ISOLATION LEVEL {SERIALIZABLE\|REPEATABLE READ}] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <tag>];` | See [Isolation Level](#isolation-level) for details on the isolation level. See [Request Priority](#request-priority) for details on the priority. The tag you set is used as both transaction tag and request tag. See also [Transaction Tags and Request Tags](#transaction-tags-and-request-tags).|
 | Commit Read-Write Transaction | `COMMIT;` | |
 | Rollback Read-Write Transaction | `ROLLBACK;` | |
 | Start Read-Only Transaction | `BEGIN RO [{<seconds>\|<RFC3339-formatted time>}] [PRIORITY {HIGH\|MEDIUM\|LOW}] [TAG <tag>];` | `<seconds>` and `<RFC3339-formatted time>` is used for stale read. See [Request Priority](#request-priority) for details on the priority. The tag you set is used as request tag. See also [Transaction Tags and Request Tags](#transaction-tags-and-request-tags).|
@@ -300,6 +300,24 @@ prompt = "[\\p:\\i:\\d]\\t> "
 3. `.spanner_cli.cnf` in current directory
 4. `.spanner_cli.cnf` in home directory(lowest)
 
+## Isolation Level
+
+You can set the isolation level at a transaction level in read-write transactions. By default `SERIALIZABLE` isolation is used for every request.
+
+To set the isolation level for a transaction, you can use the `ISOLATION LEVEL {SERIALIZABLE|REPEATABLE READ}` keyword.
+
+Here are some examples for transaction-level isolation.
+
+```
+# Read-write transaction with serializable isolation
+BEGIN RW ISOLATION LEVEL SERIALIZABLE
+
+# Read-write transaction with repeatable read isolation
+BEGIN RW ISOLATION LEVEL REPEATABLE READ
+```
+
+Note that the transaction-level isolation level cannot be set on read-only transactions.
+
 ## Request Priority
 
 You can set [request priority](https://cloud.google.com/spanner/docs/reference/rest/v1/RequestOptions#Priority) for command level or transaction level.
@@ -307,7 +325,7 @@ By default `MEDIUM` priority is used for every request.
 
 To set a priority for command line level, you can use `--priority={HIGH|MEDIUM|LOW}` command line option.
 
-To set a priority for transaction level, you can use `PRIORITY {HIGH|MEDIUM|LOW}` keyword.
+To set a priority for transaction level, you can use the `PRIORITY {HIGH|MEDIUM|LOW}` keyword.
 
 Here are some examples for transaction-level priority.
 

--- a/session.go
+++ b/session.go
@@ -119,7 +119,7 @@ func (s *Session) InReadOnlyTransaction() bool {
 }
 
 // BeginReadWriteTransaction starts read-write transaction.
-func (s *Session) BeginReadWriteTransaction(ctx context.Context, priority pb.RequestOptions_Priority, tag string) error {
+func (s *Session) BeginReadWriteTransaction(ctx context.Context, isolation_level pb.TransactionOptions_IsolationLevel, priority pb.RequestOptions_Priority, tag string) error {
 	if s.InReadWriteTransaction() {
 		return errors.New("read-write transaction is already running")
 	}
@@ -132,6 +132,7 @@ func (s *Session) BeginReadWriteTransaction(ctx context.Context, priority pb.Req
 	opts := spanner.TransactionOptions{
 		CommitOptions:  spanner.CommitOptions{ReturnCommitStats: true},
 		CommitPriority: priority,
+		IsolationLevel: isolation_level,
 		TransactionTag: tag,
 	}
 	txn, err := spanner.NewReadWriteStmtBasedTransactionWithOptions(ctx, s.client, opts)

--- a/statement_test.go
+++ b/statement_test.go
@@ -322,6 +322,45 @@ func TestBuildStatement(t *testing.T) {
 			},
 		},
 		{
+			desc:  "BEGIN RW statement with ISOLATION LEVEL",
+			input: "BEGIN RW ISOLATION LEVEL SERIALIZABLE",
+			want: &BeginRwStatement{
+				IsolationLevel: pb.TransactionOptions_SERIALIZABLE,
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with ISOLATION LEVEL",
+			input: "BEGIN RW ISOLATION LEVEL REPEATABLE READ",
+			want: &BeginRwStatement{
+				IsolationLevel: pb.TransactionOptions_REPEATABLE_READ,
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with ISOLATION LEVEL and PRIORITY",
+			input: "BEGIN RW ISOLATION LEVEL SERIALIZABLE PRIORITY MEDIUM",
+			want: &BeginRwStatement{
+				IsolationLevel: pb.TransactionOptions_SERIALIZABLE,
+				Priority:       pb.RequestOptions_PRIORITY_MEDIUM,
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with ISOLATION LEVEL and TAG",
+			input: "BEGIN RW ISOLATION LEVEL SERIALIZABLE TAG app=spanner-cli",
+			want: &BeginRwStatement{
+				IsolationLevel: pb.TransactionOptions_SERIALIZABLE,
+				Tag:            "app=spanner-cli",
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with ISOLATION LEVEL, PRIORITY and TAG",
+			input: "BEGIN RW ISOLATION LEVEL REPEATABLE READ PRIORITY MEDIUM TAG app=spanner-cli",
+			want: &BeginRwStatement{
+				IsolationLevel: pb.TransactionOptions_REPEATABLE_READ,
+				Priority:       pb.RequestOptions_PRIORITY_MEDIUM,
+				Tag:            "app=spanner-cli",
+			},
+		},
+		{
 			desc:  "BEGIN PRIORITY statement with TAG whitespace",
 			input: "BEGIN PRIORITY MEDIUM TAG app=spanner-cli env=test",
 			want: &BeginRwStatement{


### PR DESCRIPTION
Enables optionally setting the isolation level at a transaction-level to either `SERIALIZABLE` or `REPEATABLE READ`. If the isolation level is not set, Spanner will default to `SERIALIZABLE` isolation.