### PR TITLE
Upgrade Go in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23 as build
+FROM golang:1.24 as build
 WORKDIR /go/src/spanner-cli
 COPY . .
 RUN go mod download


### PR DESCRIPTION
## Before

```sh
% docker build -t spanner-cli .
...
 => ERROR [build 4/5] RUN go mod download                                                                  0.1s
------
 > [build 4/5] RUN go mod download:
0.123 go: go.mod requires go >= 1.24 (running go 1.23.11; GOTOOLCHAIN=local)
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
Dockerfile:5
--------------------
   3 |     WORKDIR /go/src/spanner-cli
   4 |     COPY . .
   5 | >>> RUN go mod download
   6 |     RUN CGO_ENABLED=0 go build -o /go/bin/spanner-cli
   7 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

## After

```sh
% docker build -t spanner-cli .
...
 => exporting to image                                                                                     0.1s
 => => exporting layers                                                                                    0.1s
 => => writing image sha256:bde2574f3feef043e8f4ed9350983ebc7164680da7891c9099d84ae0a79efef6               0.0s
 => => naming to docker.io/library/spanner-cli                                                             0.0s
```