### PR TITLE
feat: add transaction-level read lock mode support

### DIFF
--- a/session.go
+++ b/session.go
@@ -120,7 +120,7 @@ func (s *Session) InReadOnlyTransaction() bool {
 }
 
 // BeginReadWriteTransaction starts read-write transaction.
-func (s *Session) BeginReadWriteTransaction(ctx context.Context, isolation_level pb.TransactionOptions_IsolationLevel, priority pb.RequestOptions_Priority, tag string) error {
+func (s *Session) BeginReadWriteTransaction(ctx context.Context, isolation_level pb.TransactionOptions_IsolationLevel, read_lock_mode pb.TransactionOptions_ReadWrite_ReadLockMode, priority pb.RequestOptions_Priority, tag string) error {
 	if s.InReadWriteTransaction() {
 		return errors.New("read-write transaction is already running")
 	}
@@ -134,6 +134,7 @@ func (s *Session) BeginReadWriteTransaction(ctx context.Context, isolation_level
 		CommitOptions:  spanner.CommitOptions{ReturnCommitStats: true},
 		CommitPriority: priority,
 		IsolationLevel: isolation_level,
+		ReadLockMode:   read_lock_mode,
 		TransactionTag: tag,
 	}
 	txn, err := spanner.NewReadWriteStmtBasedTransactionWithOptions(ctx, s.client, opts)

--- a/session_test.go
+++ b/session_test.go
@@ -72,7 +72,7 @@ func TestRequestPriority(t *testing.T) {
 			}
 
 			// Read-Write Transaction.
-			if err := session.BeginReadWriteTransaction(ctx, pb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, test.transactionPriority, ""); err != nil {
+			if err := session.BeginReadWriteTransaction(ctx, pb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, pb.TransactionOptions_ReadWrite_READ_LOCK_MODE_UNSPECIFIED, test.transactionPriority, ""); err != nil {
 				t.Fatalf("failed to begin read write transaction: %v", err)
 			}
 			iter, _ := session.RunQuery(ctx, spanner.NewStatement("SELECT * FROM t1"))
@@ -237,7 +237,7 @@ func TestIsolationLevel(t *testing.T) {
 			}
 
 			// Read-Write Transaction.
-			if err := session.BeginReadWriteTransaction(ctx, test.isolationLevel, pb.RequestOptions_PRIORITY_UNSPECIFIED, ""); err != nil {
+			if err := session.BeginReadWriteTransaction(ctx, test.isolationLevel, pb.TransactionOptions_ReadWrite_READ_LOCK_MODE_UNSPECIFIED, pb.RequestOptions_PRIORITY_UNSPECIFIED, ""); err != nil {
 				t.Fatalf("failed to begin read write transaction: %v", err)
 			}
 			iter, _ := session.RunQuery(ctx, spanner.NewStatement("SELECT * FROM t1"))
@@ -259,6 +259,81 @@ func TestIsolationLevel(t *testing.T) {
 				case *pb.BeginTransactionRequest:
 					if got := v.GetOptions().GetIsolationLevel(); got != test.want {
 						t.Errorf("isolation level mismatch: got = %v, want = %v", got, test.want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestReadLockMode(t *testing.T) {
+	server := setupTestServer(t)
+
+	var recorder requestRecorder
+	unaryInterceptor, streamInterceptor := recordRequestsInterceptors(&recorder)
+	opts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(unaryInterceptor),
+		grpc.WithStreamInterceptor(streamInterceptor),
+	}
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx, server.Addr, opts...)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+
+	for _, test := range []struct {
+		desc         string
+		readLockMode pb.TransactionOptions_ReadWrite_ReadLockMode
+		want         pb.TransactionOptions_ReadWrite_ReadLockMode
+	}{
+		{
+			desc:         "use default unspecified read lock mode",
+			readLockMode: pb.TransactionOptions_ReadWrite_READ_LOCK_MODE_UNSPECIFIED,
+			want:         pb.TransactionOptions_ReadWrite_READ_LOCK_MODE_UNSPECIFIED,
+		},
+		{
+			desc:         "use PESSIMISTIC locking",
+			readLockMode: pb.TransactionOptions_ReadWrite_PESSIMISTIC,
+			want:         pb.TransactionOptions_ReadWrite_PESSIMISTIC,
+		},
+		{
+			desc:         "use OPTIMISTIC locking",
+			readLockMode: pb.TransactionOptions_ReadWrite_OPTIMISTIC,
+			want:         pb.TransactionOptions_ReadWrite_OPTIMISTIC,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			defer recorder.flush()
+
+			session, err := NewSession("project", "instance", "database", pb.RequestOptions_PRIORITY_UNSPECIFIED, "role", nil, nil, option.WithGRPCConn(conn))
+			if err != nil {
+				t.Fatalf("failed to create spanner-cli session: %v", err)
+			}
+
+			// Read-Write Transaction.
+			if err := session.BeginReadWriteTransaction(ctx, pb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, test.readLockMode, pb.RequestOptions_PRIORITY_UNSPECIFIED, ""); err != nil {
+				t.Fatalf("failed to begin read write transaction: %v", err)
+			}
+			iter, _ := session.RunQuery(ctx, spanner.NewStatement("SELECT * FROM t1"))
+			if err := iter.Do(func(r *spanner.Row) error {
+				return nil
+			}); err != nil {
+				t.Fatalf("failed to run query: %v", err)
+			}
+			if _, _, _, _, err := session.RunUpdate(ctx, spanner.NewStatement("DELETE FROM t1 WHERE Id = 1"), true); err != nil {
+				t.Fatalf("failed to run update: %v", err)
+			}
+			if _, err := session.CommitReadWriteTransaction(ctx); err != nil {
+				t.Fatalf("failed to commit: %v", err)
+			}
+
+			// Check request priority.
+			for _, r := range recorder.requests {
+				switch v := r.(type) {
+				case *pb.BeginTransactionRequest:
+					if got := v.GetOptions().GetReadWrite().GetReadLockMode(); got != test.want {
+						t.Errorf("read lock mode mismatch: got = %v, want = %v", got, test.want)
 					}
 				}
 			}

--- a/statement.go
+++ b/statement.go
@@ -110,7 +110,7 @@ var (
 	pdmlRe = regexp.MustCompile(`(?is)^PARTITIONED\s+((?:INSERT|UPDATE|DELETE)\s+.+$)`)
 
 	// Transaction
-	beginRwRe  = regexp.MustCompile(`(?is)^BEGIN(?:\s+RW)?(?:\s+ISOLATION LEVEL\s+(SERIALIZABLE|REPEATABLE READ))?(?:\s+PRIORITY\s+(HIGH|MEDIUM|LOW))?(?:\s+TAG\s+(.+))?$`)
+	beginRwRe  = regexp.MustCompile(`(?is)^BEGIN(?:\s+RW)?(?:\s+ISOLATION LEVEL\s+(SERIALIZABLE|REPEATABLE READ))?(?:\s+READ LOCK MODE\s+(PESSIMISTIC|OPTIMISTIC))?(?:\s+PRIORITY\s+(HIGH|MEDIUM|LOW))?(?:\s+TAG\s+(.+))?$`)
 	beginRoRe  = regexp.MustCompile(`(?is)^BEGIN\s+RO(?:\s+([^\s]+))?(?:\s+PRIORITY\s+(HIGH|MEDIUM|LOW))?(?:\s+TAG\s+(.+))?$`)
 	commitRe   = regexp.MustCompile(`(?is)^COMMIT$`)
 	rollbackRe = regexp.MustCompile(`(?is)^ROLLBACK$`)
@@ -992,6 +992,7 @@ func runInNewOrExistRwTxForExplain(ctx context.Context, session *Session, f func
 
 type BeginRwStatement struct {
 	IsolationLevel pb.TransactionOptions_IsolationLevel
+	ReadLockMode   pb.TransactionOptions_ReadWrite_ReadLockMode
 	Priority       pb.RequestOptions_Priority
 	Tag            string
 }
@@ -1009,15 +1010,23 @@ func newBeginRwStatement(input string) (*BeginRwStatement, error) {
 	}
 
 	if matched[2] != "" {
-		priority, err := parsePriority(matched[2])
+		readLockMode, err := parseReadLockMode(matched[2])
+		if err != nil {
+			return nil, err
+		}
+		stmt.ReadLockMode = readLockMode
+	}
+
+	if matched[3] != "" {
+		priority, err := parsePriority(matched[3])
 		if err != nil {
 			return nil, err
 		}
 		stmt.Priority = priority
 	}
 
-	if matched[3] != "" {
-		stmt.Tag = matched[3]
+	if matched[4] != "" {
+		stmt.Tag = matched[4]
 	}
 
 	return stmt, nil
@@ -1031,7 +1040,7 @@ func (s *BeginRwStatement) Execute(ctx context.Context, session *Session) (*Resu
 		return nil, errors.New("you're in read-only transaction. Please finish the transaction by 'CLOSE;'")
 	}
 
-	if err := session.BeginReadWriteTransaction(ctx, s.IsolationLevel, s.Priority, s.Tag); err != nil {
+	if err := session.BeginReadWriteTransaction(ctx, s.IsolationLevel, s.ReadLockMode, s.Priority, s.Tag); err != nil {
 		return nil, err
 	}
 
@@ -1208,5 +1217,16 @@ func parseIsolationLevel(isolationLevel string) (pb.TransactionOptions_Isolation
 		return pb.TransactionOptions_REPEATABLE_READ, nil
 	default:
 		return pb.TransactionOptions_ISOLATION_LEVEL_UNSPECIFIED, fmt.Errorf("invalid isolation level: %q", isolationLevel)
+	}
+}
+
+func parseReadLockMode(readLockMode string) (pb.TransactionOptions_ReadWrite_ReadLockMode, error) {
+	switch strings.ToUpper(readLockMode) {
+	case "PESSIMISTIC":
+		return pb.TransactionOptions_ReadWrite_PESSIMISTIC, nil
+	case "OPTIMISTIC":
+		return pb.TransactionOptions_ReadWrite_OPTIMISTIC, nil
+	default:
+		return pb.TransactionOptions_ReadWrite_READ_LOCK_MODE_UNSPECIFIED, fmt.Errorf("invalid read lock mode: %q", readLockMode)
 	}
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -322,14 +322,14 @@ func TestBuildStatement(t *testing.T) {
 			},
 		},
 		{
-			desc:  "BEGIN RW statement with ISOLATION LEVEL",
+			desc:  "BEGIN RW statement with ISOLATION LEVEL SERIALIZABLE",
 			input: "BEGIN RW ISOLATION LEVEL SERIALIZABLE",
 			want: &BeginRwStatement{
 				IsolationLevel: pb.TransactionOptions_SERIALIZABLE,
 			},
 		},
 		{
-			desc:  "BEGIN RW statement with ISOLATION LEVEL",
+			desc:  "BEGIN RW statement with ISOLATION LEVEL REPEATABLE READ",
 			input: "BEGIN RW ISOLATION LEVEL REPEATABLE READ",
 			want: &BeginRwStatement{
 				IsolationLevel: pb.TransactionOptions_REPEATABLE_READ,
@@ -356,6 +356,47 @@ func TestBuildStatement(t *testing.T) {
 			input: "BEGIN RW ISOLATION LEVEL REPEATABLE READ PRIORITY MEDIUM TAG app=spanner-cli",
 			want: &BeginRwStatement{
 				IsolationLevel: pb.TransactionOptions_REPEATABLE_READ,
+				Priority:       pb.RequestOptions_PRIORITY_MEDIUM,
+				Tag:            "app=spanner-cli",
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with READ LOCK MODE PESSIMISTIC",
+			input: "BEGIN RW READ LOCK MODE PESSIMISTIC",
+			want: &BeginRwStatement{
+				ReadLockMode: pb.TransactionOptions_ReadWrite_PESSIMISTIC,
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with READ LOCK MODE OPTIMISTIC",
+			input: "BEGIN RW READ LOCK MODE OPTIMISTIC",
+			want: &BeginRwStatement{
+				ReadLockMode: pb.TransactionOptions_ReadWrite_OPTIMISTIC,
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with ISOLATION LEVEL and READ LOCK MODE",
+			input: "BEGIN RW ISOLATION LEVEL SERIALIZABLE READ LOCK MODE OPTIMISTIC",
+			want: &BeginRwStatement{
+				IsolationLevel: pb.TransactionOptions_SERIALIZABLE,
+				ReadLockMode:   pb.TransactionOptions_ReadWrite_OPTIMISTIC,
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with ISOLATION LEVEL, READ LOCK MODE and TAG",
+			input: "BEGIN RW ISOLATION LEVEL REPEATABLE READ READ LOCK MODE PESSIMISTIC TAG app=spanner-cli",
+			want: &BeginRwStatement{
+				IsolationLevel: pb.TransactionOptions_REPEATABLE_READ,
+				ReadLockMode:   pb.TransactionOptions_ReadWrite_PESSIMISTIC,
+				Tag:            "app=spanner-cli",
+			},
+		},
+		{
+			desc:  "BEGIN RW statement with ISOLATION LEVEL, READ LOCK MODE, PRIORITY and TAG",
+			input: "BEGIN RW ISOLATION LEVEL REPEATABLE READ READ LOCK MODE OPTIMISTIC PRIORITY MEDIUM TAG app=spanner-cli",
+			want: &BeginRwStatement{
+				IsolationLevel: pb.TransactionOptions_REPEATABLE_READ,
+				ReadLockMode:   pb.TransactionOptions_ReadWrite_OPTIMISTIC,
 				Priority:       pb.RequestOptions_PRIORITY_MEDIUM,
 				Tag:            "app=spanner-cli",
 			},


### PR DESCRIPTION
Enables optionally setting the read lock mode at a transaction-level to either `OPTIMISTIC` or `PESSIMISTIC`. If the read lock mode is not set, Spanner will select the default read lock mode based on the isolation level of the transaction.
  - If the isolation level is `SERIALIZABLE`, then `PESSIMISTIC` locking is the default.
  - If the isolation level is `REPEATABLE READ`, then `OPTIMISTIC` locking is the default.